### PR TITLE
ssh-dss-sha256@ssh.com no longer supported

### DIFF
--- a/_data/impls/smartftp.yml
+++ b/_data/impls/smartftp.yml
@@ -24,7 +24,6 @@ protocols:
     hostkey:
         - ssh-rsa
         - ssh-dss
-        - ssh-dss-sha256@ssh.com
         - ssh-rsa-sha256@ssh.com
         - ecdsa-sha2-nistp256
         - ecdsa-sha2-nistp384


### PR DESCRIPTION
Removed because there is no public specification available and due to compatibility issues with Tectia