### PR TITLE
arcfour has now been removed

### DIFF
--- a/_data/impls/smartftp.yml
+++ b/_data/impls/smartftp.yml
@@ -22,7 +22,6 @@ protocols:
         - aes192-cbc
         - aes256-cbc
         - 3des-cbc
-        - arcfour                       # disabled by default
     compression:
         - zlib
         - zlib@openssh.com

--- a/_data/impls/smartftp.yml
+++ b/_data/impls/smartftp.yml
@@ -2,8 +2,8 @@ name: SmartFTP
 homepage: https://www.smartftp.com/
 license: Proprietary
 latest-release:
-    version: 6.0.2146
-    date: 2015-05-28
+    version: 6.0.2165
+    date: 2015-10-27
 changelog: https://www.smartftp.com/changelog/1
 client: yes
 server: no


### PR DESCRIPTION
"Version 4.0.475
2015-09-05
SSH: Removed deprecated RC4 (arcfour*) ciphers"

Reference: https://www.smartftp.com/changelog/2