### PR TITLE
Changed license type for SSHJ

### DIFF
--- a/_data/impls/sshj.yml
+++ b/_data/impls/sshj.yml
@@ -2,7 +2,7 @@ name: SSHJ
 homepage: https://github.com/hierynomus/sshj
 source-repository: https://github.com/hierynomus/sshj
 changelog: https://github.com/hierynomus/sshj
-license: APL-2.0
+license: Apache 2.0
 latest-release:
     version: 0.14.0
     date: 2015-11-04


### PR DESCRIPTION
APL != Apache 2.0 (APL is the Adaptive Public License, see: https://opensource.org/licenses/APL-1.0)