### PR TITLE
Updated ConnectBot hostkey support

### DIFF
--- a/_impls/connectbot.md
+++ b/_impls/connectbot.md
@@ -30,6 +30,7 @@ protocols:
     compression:
         - none
     hostkey:
+        - curve25519-sha256
         - ecdsa-sha2-nistp256
         - ecdsa-sha2-nistp384
         - ecdsa-sha2-nistp521


### PR DESCRIPTION
ConnectBot now supports curve25519-sha256 keys (server-side only for now), as per the below:
https://github.com/connectbot/connectbot/pull/370
