### PR TITLE
Update AsyncSSH to cover version 1.13.1

### DIFF
--- a/_impls/asyncssh.md
+++ b/_impls/asyncssh.md
@@ -6,20 +6,20 @@ license: "[EPL v1.0](http://www.eclipse.org/legal/epl-v10.html)"
 first-release:
     date: 2013-09-14
 latest-release:
-    version: 1.13.0
-    date: 2018-05-20
+    version: 1.13.1
+    date: 2018-06-16
 changelog: http://asyncssh.readthedocs.io/en/latest/changes.html
 client: yes
 server: yes
 
 protocols:
     cipher:
-        - chacha20-poly1305@openssh.com             # since 1.0.0
+        - chacha20-poly1305@openssh.com                 # since 1.0.0
         - aes256-ctr
         - aes192-ctr
         - aes128-ctr
-        - aes256-gcm@openssh.com                    # since 0.9.0
-        - aes128-gcm@openssh.com                    # since 0.9.0
+        - aes256-gcm@openssh.com                        # since 0.9.0
+        - aes128-gcm@openssh.com                        # since 0.9.0
         - aes256-cbc
         - aes192-cbc
         - aes128-cbc
@@ -34,57 +34,63 @@ protocols:
         - zlib
         - none
     hostkey:
-        - "null"                                    # since 1.9.0
-        - ssh-ed25519-cert-v01@openssh.com          # since 1.0.0
-        - ecdsa-sha2-nistp521-cert-v01@openssh.com  # since 1.0.0
-        - ecdsa-sha2-nistp384-cert-v01@openssh.com  # since 1.0.0
-        - ecdsa-sha2-nistp256-cert-v01@openssh.com  # since 1.0.0
-        - ssh-rsa-cert-v01@openssh.com              # since 1.0.0
-        - ssh-dss-cert-v01@openssh.com              # since 1.0.0
-        #- ssh-rsa-cert-v00@openssh.com             # removed in 1.3.2
-        #- ssh-dss-cert-v00@openssh.com             # removed in 1.3.2
-        - x509v3-ecdsa-sha2-nistp521                # since 1.11.0
-        - x509v3-ecdsa-sha2-nistp384                # since 1.11.0
-        - x509v3-ecdsa-sha2-nistp256                # since 1.11.0
-        - x509v3-rsa2048-sha256                     # since 1.11.0
-        - x509v3-ssh-rsa                            # since 1.11.0
-        - x509v3-ssh-dss                            # since 1.11.0
-        - ssh-ed25519                               # since 1.0.0
-        - ecdsa-sha2-nistp521                       # since 1.0.0
-        - ecdsa-sha2-nistp384                       # since 1.0.0
-        - ecdsa-sha2-nistp256                       # since 1.0.0
-        - rsa-sha2-256                              # since 1.7.0
-        - rsa-sha2-512                              # since 1.7.0
+        - "null"                                        # since 1.9.0
+        - ssh-ed25519-cert-v01@openssh.com              # since 1.0.0
+        - ecdsa-sha2-nistp521-cert-v01@openssh.com      # since 1.0.0
+        - ecdsa-sha2-nistp384-cert-v01@openssh.com      # since 1.0.0
+        - ecdsa-sha2-nistp256-cert-v01@openssh.com      # since 1.0.0
+        - ecdsa-sha2-1.3.132.0.10-cert-v01@openssh.com  # since 1.0.0
+        - ssh-rsa-cert-v01@openssh.com                  # since 1.0.0
+        - ssh-dss-cert-v01@openssh.com                  # since 1.0.0
+        #- ssh-rsa-cert-v00@openssh.com                 # removed in 1.3.2
+        #- ssh-dss-cert-v00@openssh.com                 # removed in 1.3.2
+        - x509v3-ecdsa-sha2-nistp521                    # since 1.11.0
+        - x509v3-ecdsa-sha2-nistp384                    # since 1.11.0
+        - x509v3-ecdsa-sha2-nistp256                    # since 1.11.0
+        - x509v3-ecdsa-sha2-1.3.132.0.10                # since 1.13.1
+        - x509v3-rsa2048-sha256                         # since 1.11.0
+        - x509v3-ssh-rsa                                # since 1.11.0
+        - x509v3-ssh-dss                                # since 1.11.0
+        - ssh-ed25519                                   # since 1.0.0
+        - ecdsa-sha2-nistp521                           # since 1.0.0
+        - ecdsa-sha2-nistp384                           # since 1.0.0
+        - ecdsa-sha2-nistp256                           # since 1.0.0
+        - ecdsa-sha2-1.3.132.0.10                       # since 1.13.1
+        - rsa-sha2-256                                  # since 1.7.0
+        - rsa-sha2-512                                  # since 1.7.0
         - ssh-rsa
         - ssh-dss
     kex:
-        - gss-gex-sha256-*                          # since 1.9.0
-        - gss-gex-sha1-*                            # since 1.9.0
-        - gss-group1-sha1-*                         # since 1.9.0
-        - gss-group14-sha1-*                        # since 1.9.0
-        - gss-group14-sha256-*                      # since 1.9.0
-        - gss-group15-sha512-*                      # since 1.9.0
-        - gss-group16-sha512-*                      # since 1.9.0
-        - gss-group17-sha512-*                      # since 1.9.0
-        - gss-group18-sha512-*                      # since 1.9.0
-        - curve25519-sha256                         # since 1.8.0
-        - curve25519-sha256@libssh.org              # since 1.0.0
-        - ecdh-sha2-nistp521                        # since 1.0.0
-        - ecdh-sha2-nistp384                        # since 1.0.0
-        - ecdh-sha2-nistp256                        # since 1.0.0
+        - gss-gex-sha256-*                              # since 1.9.0
+        - gss-gex-sha1-*                                # since 1.9.0
+        - gss-group1-sha1-*                             # since 1.9.0
+        - gss-group14-sha1-*                            # since 1.9.0
+        - gss-group14-sha256-*                          # since 1.9.0
+        - gss-group15-sha512-*                          # since 1.9.0
+        - gss-group16-sha512-*                          # since 1.9.0
+        - gss-group17-sha512-*                          # since 1.9.0
+        - gss-group18-sha512-*                          # since 1.9.0
+        - curve25519-sha256                             # since 1.8.0
+        - curve25519-sha256@libssh.org                  # since 1.0.0
+        - ecdh-sha2-nistp521                            # since 1.0.0
+        - ecdh-sha2-nistp384                            # since 1.0.0
+        - ecdh-sha2-nistp256                            # since 1.0.0
+        - ecdh-sha2-1.3.132.0.10                        # since 1.13.1
         - diffie-hellman-group-exchange-sha256
         - diffie-hellman-group-exchange-sha1
         - diffie-hellman-group1-sha1
         - diffie-hellman-group14-sha1
-        - diffie-hellman-group14-sha256             # since 1.7.0
-        - diffie-hellman-group15-sha512             # since 1.9.0
-        - diffie-hellman-group16-sha512             # since 1.7.0
-        - diffie-hellman-group17-sha512             # since 1.9.0
-        - diffie-hellman-group18-sha512             # since 1.7.0
-        - ext-info-c                                # since 1.7.0
+        - diffie-hellman-group14-sha256                 # since 1.7.0
+        - diffie-hellman-group15-sha512                 # since 1.9.0
+        - diffie-hellman-group16-sha512                 # since 1.7.0
+        - diffie-hellman-group17-sha512                 # since 1.9.0
+        - diffie-hellman-group18-sha512                 # since 1.7.0
+        - rsa2048-sha256                                # since 1.13.1
+        - rsa1024-sha1                                  # since 1.13.1
+        - ext-info-c                                    # since 1.7.0
     mac:
-        - umac-64-etm@openssh.com                   # since 1.8.0
-        - umac-128-etm@openssh.com                  # since 1.8.0
+        - umac-64-etm@openssh.com                       # since 1.8.0
+        - umac-128-etm@openssh.com                      # since 1.8.0
         - hmac-sha2-256-etm@openssh.com
         - hmac-sha2-512-etm@openssh.com
         - hmac-sha1-etm@openssh.com
@@ -93,8 +99,8 @@ protocols:
         - hmac-sha2-512-96-etm@openssh.com
         - hmac-sha1-96-etm@openssh.com
         - hmac-md5-96-etm@openssh.com
-        - umac-64@openssh.com                       # since 1.8.0
-        - umac-128@openssh.com                      # since 1.8.0
+        - umac-64@openssh.com                           # since 1.8.0
+        - umac-128@openssh.com                          # since 1.8.0
         - hmac-sha2-256
         - hmac-sha2-512
         - hmac-sha1
@@ -104,13 +110,14 @@ protocols:
         - hmac-sha1-96
         - hmac-md5-96
     userauth:
-        - gssapi-keyex                              # since 1.9.0
-        - gssapi-with-mic                           # since 1.9.0
+        - gssapi-keyex                                  # since 1.9.0
+        - gssapi-with-mic                               # since 1.9.0
+        - hostbased                                     # since 1.13.1
         - publickey
         - keyboard-interactive
         - password
     extension:
-        - server-sig-algs                           # since 1.7.0
+        - server-sig-algs                               # since 1.7.0
 
 first_kex_packet_follows: 1
 ---


### PR DESCRIPTION
This commit updates the AsyncSSH entry to list the latest version number
and release date and to show support for RSA key exchange algorithms,
the SECP256K1 elliptic curve for ECDSA and ECDH, and hostbased user
authentication.