### PR TITLE
Update Dropbear to 2022.82

### DIFF
--- a/_impls/dropbear.md
+++ b/_impls/dropbear.md
@@ -6,8 +6,8 @@ license: "[MIT style](https://secure.ucc.asn.au/hg/dropbear/raw-file/tip/LICENSE
 first-release:
     date: 2003-04-06    # according to CHANGES file
 latest-release:
-    version: 2016.73
-    date: 2016-03-18
+    version: 2022.82
+    date: 2022-04-01
 changelog: https://matt.ucc.asn.au/dropbear/CHANGES
 client: yes
 server: yes
@@ -18,16 +18,15 @@ protocols:
     cipher:
         - aes128-ctr
         - aes256-ctr
-        #- twofish256-ctr           # Disabled by default
-        #- twofish128-ctr           # Disabled by default
-        - aes128-cbc
-        - aes256-cbc
-        - twofish256-cbc
-        - twofish-cbc
-        - twofish128-cbc
-        - 3des-ctr
-        - 3des-cbc
-        #- blowfish-cbc             # Disabled by default
+        - chacha20-poly1305@openssh.com  # since 2020.79
+        # - aes128-gcm@openssh.com        # since 2020.79, disabled by default
+        # - aes128-gcm@openssh.com        # since 2020.79, disabled by default
+
+        # - aes128-cbc          # disabled by default
+        # - aes256-cbc          # disabled by default
+        # - 3des-ctr            # disabled by default
+        # - 3des-cbc            # disabled by default
+        # - 3des-cbc            # disabled by default
     compression:
         - zlib@openssh.com
         - zlib
@@ -37,28 +36,33 @@ protocols:
         - ecdsa-sha2-nistp384
         - ecdsa-sha2-nistp521
         - ssh-rsa
+        - rsa-sha2-256                   # since 2022.82
         - ssh-dss
+        - ssh-ed25519                    # since 2020.79
+        - sk-ssh-ed25519@openssh.com     # since 2022.82
+        - sk-ecdsa-sha2-nistp256@openssh.com     # since 2022.82
     kex:
-        - curve25519-sha256@libssh.org
+        - curve25519                     # since 2018.76
+        - curve25519-sha256@libssh.org   # since 2013.62
         - ecdh-sha2-nistp521
         - ecdh-sha2-nistp384
         - ecdh-sha2-nistp256
         - diffie-hellman-group14-sha1
-        - diffie-hellman-group1-sha1
+        - diffie-hellman-group14-sha256   # since 2018.76
+        # - diffie-hellman-group16-sha512   # since 2018.76. disabled by default
+        # - diffie-hellman-group1-sha1    # disabled by default
         - kexguess2@matt.ucc.asn.au     # Dropbear extension (only documented in their CHANGES file?)
     mac:
-        - hmac-sha1-96
+        # - hmac-sha1-96   # disabled by default
         - hmac-sha1
         - hmac-sha2-256
-        - hmac-sha2-512
-        - hmac-md5
     userauth:
         - publickey
         - password
         - keyboard-interactive
 
 first_kex_packet_follows: 1
-ident: "SSH-2.0-dropbear_2015.71"
+ident: "SSH-2.0-dropbear_2022.82"
 ---
 * Server and client for POSIX-based platforms.
 * [Wikipedia](https://en.wikipedia.org/wiki/Dropbear_%28software%29)


### PR DESCRIPTION
I've commented out "disabled by default" options since it's configured at compile time rather than a config file.

This supersedes #75