### PR TITLE
Update CycloneSSH to version 2.1.6

### DIFF
--- a/_impls/cyclonessh.md
+++ b/_impls/cyclonessh.md
@@ -6,8 +6,8 @@ license: "Dual license: [GPLv2](http://www.gnu.org/licenses/old-licenses/gpl-2.0
 first-release:
     date: 2019-07-19
 latest-release:
-    version: 2.1.2
-    date: 2021-11-15
+    version: 2.1.6
+    date: 2022-05-31
 changelog: https://www.oryx-embedded.com/download.html#changelog
 client: yes
 server: yes
@@ -17,15 +17,19 @@ protocols:
         - chacha20-poly1305@openssh.com
         - aes128-gcm@openssh.com
         - aes256-gcm@openssh.com
+        - AEAD_AES_128_GCM
+        - AEAD_AES_256_GCM
+        - AEAD_CAMELLIA_128_GCM
+        - AEAD_CAMELLIA_256_GCM
         - aes128-ctr
         - aes192-ctr
         - aes256-ctr
-        - aes128-cbc
-        - aes192-cbc
-        - aes256-cbc
         - camellia128-ctr
         - camellia192-ctr
         - camellia256-ctr
+        - aes128-cbc
+        - aes192-cbc
+        - aes256-cbc
         - camellia128-cbc
         - camellia192-cbc
         - camellia256-cbc
@@ -42,14 +46,22 @@ protocols:
     compression:
         - none
     hostkey:
+        - ssh-ed25519-cert-v01@openssh.com
         - ssh-ed25519
         - ssh-ed448
+        - ecdsa-sha2-nistp256-cert-v01@openssh.com
         - ecdsa-sha2-nistp256
+        - ecdsa-sha2-nistp384-cert-v01@openssh.com
         - ecdsa-sha2-nistp384
+        - ecdsa-sha2-nistp521-cert-v01@openssh.com
         - ecdsa-sha2-nistp521
+        - rsa-sha2-256-cert-v01@openssh.com
         - rsa-sha2-256
+        - rsa-sha2-512-cert-v01@openssh.com
         - rsa-sha2-512
+        - ssh-rsa-cert-v01@openssh.com
         - ssh-rsa
+        - ssh-dss-cert-v01@openssh.com
         - ssh-dss
     kex:
         - curve25519-sha256
@@ -63,6 +75,8 @@ protocols:
         - diffie-hellman-group14-sha256
         - diffie-hellman-group14-sha1
         - diffie-hellman-group1-sha1
+        - ext-info-c
+        - ext-info-s
     mac:
         - hmac-sha2-256
         - hmac-sha2-256-etm@openssh.com
@@ -78,10 +92,16 @@ protocols:
         - hmac-md5-etm@openssh.com
         - hmac-md5-96
         - hmac-md5-96-etm@openssh.com
+        - AEAD_AES_128_GCM
+        - AEAD_AES_256_GCM
+        - AEAD_CAMELLIA_128_GCM
+        - AEAD_CAMELLIA_256_GCM
     userauth:
         - publickey
         - password
     extension:
+        - server-sig-algs
+        - global-requests-ok
 
 first_kex_packet_follows: 0
 ---


### PR DESCRIPTION
Hello,

CycloneSSH has been updated to version 2.1.6. Main changes are:
- Added support for certificate-based authentication
- Added support for SSH extensions
- Added support for AEAD_AES_128_GCM and AEAD_AES_256_GCM encryption algorithms as per RFC 5647

Nick