### PR TITLE
Update AsyncSSH to cover version 2.13.0

### DIFF
--- a/_impls/asyncssh.md
+++ b/_impls/asyncssh.md
@@ -6,8 +6,8 @@ license: "[EPL v2.0](https://www.eclipse.org/legal/epl-2.0/faq.php)"
 first-release:
     date: 2013-09-14
 latest-release:
-    version: 2.10.0
-    date: 2022-03-26
+    version: 2.13.0
+    date: 2022-12-27
 changelog: http://asyncssh.readthedocs.io/en/latest/changes.html
 client: yes
 server: yes
@@ -91,6 +91,7 @@ protocols:
         - gss-group18-sha512-*                          # since 1.9.0
         - gss-group14-sha1-*                            # since 1.9.0
         - gss-group1-sha1-*                             # since 1.9.0
+        - sntrup761x25519-sha512@openssh.com            # since 2.12.0
         - curve25519-sha256                             # since 1.8.0
         - curve25519-sha256@libssh.org                  # since 1.0.0
         - curve448-sha512                               # since 1.16.0


### PR DESCRIPTION
This commit updates the AsyncSSH latest version and also adds the sntrup761x25519-sha512@openssh.com kex algorithm which is supported in 2.12.0 and later.