### PR TITLE
Update SSH.NET to version 2020.0.2

### DIFF
--- a/_impls/ssh-net.md
+++ b/_impls/ssh-net.md
@@ -1,19 +1,18 @@
 ---
 title: SSH.NET
-homepage: https://sshnet.codeplex.com/
-source-repository: https://sshnet.svn.codeplex.com/svn
-license: "[BSD style](https://sshnet.codeplex.com/license)"
-#first-release:
-#    date: YYYY-MM-DD
+homepage: https://github.com/sshnet/SSH.NET/
+source-repository: https://github.com/sshnet/SSH.NET.git
+license: "[MIT license](https://github.com/sshnet/SSH.NET/blob/develop/LICENSE)"
+first-release:
+    date: 2010-09-16
 latest-release:
-    version: 2014.4.6-beta2
-    date: 2014-11-22
-#changelog: TODO
-client: no
+    version: 2020.0.2-pre
+    date: 2020-05-29
+changelog: https://github.com/sshnet/SSH.NET/releases
+client: yes
 server: no
 library: client
 
-# sftp; SOCKS4, SOCKS5 and HTTP Proxy
 protocols:
     cipher:
         - aes256-ctr
@@ -35,25 +34,42 @@ protocols:
     compression:
         - none
     hostkey:
+        - ssh-ed25519
+        - ecdsa-sha2-nistp256
+        - ecdsa-sha2-nistp384
+        - ecdsa-sha2-nistp521
         - ssh-rsa
         - ssh-dss
     kex:
+        - curve25519-sha256
+        - curve25519-sha256@libssh.org
+        - ecdh-sha2-nistp256
+        - ecdh-sha2-nistp384
+        - ecdh-sha2-nistp521
         - diffie-hellman-group-exchange-sha256
         - diffie-hellman-group-exchange-sha1
+        - diffie-hellman-group16-sha512
+        - diffie-hellman-group14-sha256
         - diffie-hellman-group14-sha1
         - diffie-hellman-group1-sha1
     mac:
         - hmac-md5
+        - hmac-md5-96
         - hmac-sha1
+        - hmac-sha1-96
         - hmac-sha2-256
         - hmac-sha2-256-96
+        - hmac-sha2-512
+        - hmac-sha2-512-96
         - hmac-ripemd160
         - hmac-ripemd160@openssh.com
-        - hmac-md5-96
-        - hmac-sha1-96
     userauth:
         - publickey
         - password
         - keyboard-interactive
 ---
 * Library for .NET.
+* Supports SFTP, SCP
+* Supports SOCKS4, SOCKS5 and HTTP proxies
+* Supports remote, dynamic and local port forwarding
+* Supports two-factor or higher authentication


### PR DESCRIPTION
Technical information from https://github.com/sshnet/SSH.NET/blob/457789947c284fc8cd377e9be400af7356e086b4/README.md
First release information from https://web.archive.org/web/20101229095130/http://sshnet.codeplex.com/releases/view/52439