### PR TITLE
Add strict kex

### DIFF
--- a/_data/specs.yml
+++ b/_data/specs.yml
@@ -432,6 +432,9 @@ openssh:
             #- hmac-ripemd160-etm@openssh.com   # Undocumented? openssh/myproposal.h
         kex:
             - sntrup761x25519-sha512@openssh.com # see also https://www.openssh.com/txt/release-9.0
+        extension:
+            - kex-strict-c-v00@openssh.com
+            - kex-strict-s-v00@openssh.com
 
 openssh-chacha:
     name: OpenSSH

--- a/_impls/absolutetelnet.md
+++ b/_impls/absolutetelnet.md
@@ -55,7 +55,9 @@ protocols:
         - keyboard-interactive
         - gssapi-with-mic
         - hostbased
-
+    extension:
+        - kex-strict-c-v00@openssh.com  # since 12.11
+        - kex-strict-s-v00@openssh.com  # since 12.11
 
 # X11 forwarding, Port forwarding, sftp client, telnet client
 ---

--- a/_impls/apache-sshd.md
+++ b/_impls/apache-sshd.md
@@ -64,7 +64,7 @@ protocols:
         - hmac-md5
         - hmac-sha1
         - hmac-sha2-256
-        - hmac-sha2-512             # was brokeb before 1.1.0
+        - hmac-sha2-512                 # was brokeb before 1.1.0
         - hmac-sha1-96
         - hmac-md5-96
         - hmac-sha1-etm@openssh.com
@@ -74,6 +74,9 @@ protocols:
         - keyboard-interactive
         - password
         - publickey
-        - gssapi-with-mic           # only OID 1.2.840.113554.1.2.2 / Kerberos
+        - gssapi-with-mic               # only OID 1.2.840.113554.1.2.2 / Kerberos
+    extension:
+        - kex-strict-c-v00@openssh.com  # since 2.12.0
+        - kex-strict-s-v00@openssh.com  # since 2.12.0
 ---
 * Pure Java implementation.

--- a/_impls/asyncssh.md
+++ b/_impls/asyncssh.md
@@ -153,6 +153,8 @@ protocols:
         - password
     extension:
         - server-sig-algs                               # since 1.7.0
+        - kex-strict-c-v00@openssh.com                  # since 2.14.2
+        - kex-strict-s-v00@openssh.com                  # since 2.14.2
 
 first_kex_packet_follows: 1
 ---

--- a/_impls/bitvise.md
+++ b/_impls/bitvise.md
@@ -61,6 +61,8 @@ protocols:
     extension:
         - elevation
         - server-sig-algs
+        - kex-strict-c-v00@openssh.com  # since 9.33
+        - kex-strict-s-v00@openssh.com  # since 9.33
 
 # The following information was provided by denis bider.
 #

--- a/_impls/connectbot.md
+++ b/_impls/connectbot.md
@@ -62,6 +62,8 @@ protocols:
         - publickey
     extension:
         - server-sig-algs
+        - kex-strict-c-v00@openssh.com  # since 1.9.10
+        - kex-strict-s-v00@openssh.com  # since 1.9.10
 
 first_kex_packet_follows: 0
 ident: " SSH-2.0-TrileadSSH2Java_213"

--- a/_impls/cyclonessh.md
+++ b/_impls/cyclonessh.md
@@ -127,6 +127,8 @@ protocols:
     extension:
         - server-sig-algs
         - global-requests-ok
+        - kex-strict-c-v00@openssh.com  # since 2.3.4
+        - kex-strict-s-v00@openssh.com  # since 2.3.4
 
 first_kex_packet_follows: 0
 ---

--- a/_impls/erlang.md
+++ b/_impls/erlang.md
@@ -67,6 +67,9 @@ protocols:
         - keyboard-interactive
     extension:
         - server-sig-algs                   # since 4.5
+    extension:
+        - kex-strict-c-v00@openssh.com      # since 26.2.1 / 25.3.2.8 / 24.3.4.15
+        - kex-strict-s-v00@openssh.com      # since 26.2.1 / 25.3.2.8 / 24.3.4.15
 ---
 * Server and client implementation (and library) for the 
   [Erlang](http://www.erlang.org/) programming language.

--- a/_impls/flowssh.md
+++ b/_impls/flowssh.md
@@ -55,6 +55,8 @@ protocols:
     extension:
         - elevation
         - server-sig-algs
+        - kex-strict-c-v00@openssh.com  # since 9.32
+        - kex-strict-s-v00@openssh.com  # since 9.32
 ---
 * Bitvise FlowSshC/Cpp/Net is a SSH library for C, C++, and .NET.
 * 2015-07-10: The information provided here is based on the FlowSshC.h header file,

--- a/_impls/jsch.md
+++ b/_impls/jsch.md
@@ -114,6 +114,8 @@ protocols:
         - publickey
     extension:
         - server-sig-algs
+        - kex-strict-c-v00@openssh.com  # since 0.2.15
+        - kex-strict-s-v00@openssh.com  # since 0.2.15
 ---
 * Pure Java implementation.
 * This is a fork of the original [JSch project](https://sourceforge.net/projects/jsch/)

--- a/_impls/libssh.md
+++ b/_impls/libssh.md
@@ -80,6 +80,9 @@ protocols:
         - hostbased
         - keyboard-interactive
         - gssapi-with-mic
+    extension:
+        - kex-strict-c-v00@openssh.com  # since 0.10.6 / 0.9.8
+        - kex-strict-s-v00@openssh.com  # since 0.10.6 / 0.9.8
 ---
 * Mulitplatform C library for clients and servers.
 * Not to be confused with the unrelated [libssh2](/impls/libssh2.html)

--- a/_impls/openssh.md
+++ b/_impls/openssh.md
@@ -103,6 +103,8 @@ protocols:
         - hostbased
     extension:
         - server-sig-algs                   # since 7.2
+        - kex-strict-c-v00@openssh.com      # since 9.6
+        - kex-strict-s-v00@openssh.com      # since 9.6
 
 first_kex_packet_follows: 0
 ---

--- a/_impls/paramiko.md
+++ b/_impls/paramiko.md
@@ -56,6 +56,9 @@ protocols:
         - keyboard-interactive
         - gssapi-with-mic       # since 1.15.0 (2014-09-18) # only OID 1.2.840.113554.1.2.2 / Kerberos
         - gssapi-keyex          # since 1.15.0 (2014-09-18)
+    extension:
+        - kex-strict-c-v00@openssh.com  # since 3.4.0
+        - kex-strict-s-v00@openssh.com  # since 3.4.0
 ---
 * [Python](https://www.python.org/) library.
 * Built on [PyCrypto](http://pycrypto.org/), a Python C extension for low level cryptography.

--- a/_impls/phpseclib.md
+++ b/_impls/phpseclib.md
@@ -81,5 +81,8 @@ protocols:
         - keyboard-interactive
         - publickey
         - password
+    extension:
+        - kex-strict-c-v00@openssh.com  # since 3.0.35 / 2.0.46 / 1.0.22
+        - kex-strict-s-v00@openssh.com  # since 3.0.35 / 2.0.46 / 1.0.22
 ---
 * Pure PHP implementation.

--- a/_impls/putty.md
+++ b/_impls/putty.md
@@ -76,5 +76,8 @@ protocols:
         - password
         - keyboard-interactive
         - gssapi-with-mic
+    extension:
+        - kex-strict-c-v00@openssh.com  # since 0.80
+        - kex-strict-s-v00@openssh.com  # since 0.80
 ---
 * [Wikipedia](https://en.wikipedia.org/wiki/PuTTY)

--- a/_impls/securecrt.md
+++ b/_impls/securecrt.md
@@ -60,7 +60,9 @@ protocols:
         - keyboard-interactive
         - gssapi-with-mic
         - gssapi-keyex
-
+    extension:
+        - kex-strict-c-v00@openssh.com  # since 9.4.3
+        - kex-strict-s-v00@openssh.com  # since 9.4.3
 
 #sftp-su@vandyke.com
 #read-directory-changes@vandyke.com

--- a/_impls/smartftp.md
+++ b/_impls/smartftp.md
@@ -69,6 +69,8 @@ protocols:
     extension:
         - server-sig-algs
         - no-flow-control
+        - kex-strict-c-v00@openssh.com  # since 10.0.3190
+        - kex-strict-s-v00@openssh.com  # since 10.0.3190
 ---
 * Windows client.
 * Supports FTP, FTPS, SFTP, WebDAV, S3, Google Drive, Microsoft OneDrive, Backblaze, SSH, Terminal client.

--- a/_impls/sshj.md
+++ b/_impls/sshj.md
@@ -108,5 +108,8 @@ protocols:
         - keyboard-interactive
         - gssapi-with-mic
         - hostbased
+    extension:
+        - kex-strict-c-v00@openssh.com  # since 0.38.0
+        - kex-strict-s-v00@openssh.com  # since 0.38.0
 ---
 * Pure Java implementation.

--- a/_impls/tectia-ssh.md
+++ b/_impls/tectia-ssh.md
@@ -98,6 +98,9 @@ protocols:
         #- RSA SecurID       # through keyboard-interactive
         #- RADIUS            # through keyboard-interactive
         #- LAM               # through keyboard-interactive / AIX only
+    extension:
+        - kex-strict-c-v00@openssh.com  # since 6.6.3
+        - kex-strict-s-v00@openssh.com  # since 6.6.3
 ---
 * Formerly known as just "SSH" or "ssh.com"
 * Strictly speaking, the Tectica SSH client and server are two separate

--- a/_impls/thrussh.md
+++ b/_impls/thrussh.md
@@ -31,6 +31,8 @@ protocols:
         - password
         - keyboard-interactive
         - hostbased
-
+    extension:
+        - kex-strict-c-v00@openssh.com  # since 0.35.1
+        - kex-strict-s-v00@openssh.com  # since 0.35.1
 ---
 * Multiplatform Rust library for clients and servers.

--- a/_impls/tinyssh.md
+++ b/_impls/tinyssh.md
@@ -33,5 +33,8 @@ protocols:
         - hmac-sha2-256
     userauth:
         - publickey
+    extension:
+        - kex-strict-c-v00@openssh.com  # since 20240101
+        - kex-strict-s-v00@openssh.com  # since 20240101
 ---
 * Minimalistic SSH implementation, still in alpha stage.

--- a/_impls/ttssh2.md
+++ b/_impls/ttssh2.md
@@ -72,6 +72,9 @@ protocols:
         - password
         - publickey
         - keyboard-interactive
+    extension:
+        - kex-strict-c-v00@openssh.com  # since 5.1 / 4.108
+        - kex-strict-s-v00@openssh.com  # since 5.1 / 4.108
 
 ident: "SSH-2.0-TTSSH/2.75 Win32"
 ---

--- a/_impls/webssh.md
+++ b/_impls/webssh.md
@@ -47,6 +47,9 @@ protocols:
         - keyboard-interactive
         - publickey
         - password
+    extension:
+        - kex-strict-c-v00@openssh.com  # since 24.8
+        - kex-strict-s-v00@openssh.com  # since 24.8
 
 first_kex_packet_follows: 0
 ident: "SSH-2.0-PuTTY_Release_0.63"

--- a/_impls/xshell.md
+++ b/_impls/xshell.md
@@ -69,6 +69,9 @@ protocols:
         - gssapi-with-mic
         - password
         - keyboard-interactive
+    extension:
+        - kex-strict-c-v00@openssh.com  # since version 0144
+        - kex-strict-s-v00@openssh.com  # since version 0144
 
 first_kex_packet_follows: 0
 ident: "SSH-2.0-nsssh2_5.0.0030 NetSarang Computer, Inc."


### PR DESCRIPTION
This PR adds both client and server extensions to the specification page and all implementations that support these extensions.

I added both client and server extensions separately, even though I could not find an implementation that includes either one. So either both are supported, or none.

I did not list implementations with support in unreleased versions, such as Dropbear and libssh2.

The information about support is gathered primarily from the liste patches on the Terrapin website. I added a couple of other implementations based on the changelog referenced from the existing spec file.

Finally I noticed that some implementations did not contain an extensions variable in the spec file. As a result a couple of implementations now list several other extensions as 'no/unsupported'.  Note that I did not check support for other extensions, so please let me know if this is an issue.

This closes #103 