### PR TITLE
Paramiko, AsyncSSH, Apache SSHD, SSHJ, OpenSSH & PuTTY updates

### DIFF
--- a/_data/specs.yml
+++ b/_data/specs.yml
@@ -459,6 +459,8 @@ openssh-certkeys:
             - ecdsa-sha2-nistp384-cert-v01@openssh.com
             - ecdsa-sha2-nistp521-cert-v01@openssh.com
             - ssh-ed25519-cert-v01@openssh.com
+            - rsa-sha2-256-cert-v01@openssh.com
+            - rsa-sha2-512-cert-v01@openssh.com
 
 openssh-u2f:
     name: OpenSSH

--- a/_impls/apache-sshd.md
+++ b/_impls/apache-sshd.md
@@ -1,13 +1,13 @@
 ---
 title: Apache SSHD
-homepage: http://mina.apache.org/sshd-project/
-source-repository: http://git-wip-us.apache.org/repos/asf/mina-sshd.git
+homepage: https://mina.apache.org/sshd-project/
+source-repository: https://github.com/apache/mina-sshd
 license: "[Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0)"
 first-release:
     date: 2009      # according to Wikipedia
 latest-release:
-    version: 2.4.0
-    date: 2020-01-17
+    version: 2.13.1
+    date: 2024-06-24
 changelog: "https://github.com/apache/mina-sshd/blob/master/CHANGES.md"
 client: yes
 server: yes
@@ -24,6 +24,9 @@ protocols:
         - blowfish-cbc
         - aes192-cbc
         - aes256-cbc
+        - aes128-gcm@openssh.com
+        - aes256-gcm@openssh.com
+        - chacha20-poly1305@openssh.com
     compression:
         - zlib
         - zlib@openssh.com
@@ -60,6 +63,10 @@ protocols:
         - diffie-hellman-group16-sha512
         - diffie-hellman-group17-sha512
         - diffie-hellman-group18-sha512
+        - curve25519-sha256
+        - curve25519-sha256@libssh.org
+        - curve448-sha512
+        - sntrup761x25519-sha512@openssh.com
     mac:
         - hmac-md5
         - hmac-sha1
@@ -75,5 +82,6 @@ protocols:
         - password
         - publickey
         - gssapi-with-mic           # only OID 1.2.840.113554.1.2.2 / Kerberos
+        - hostbased
 ---
 * Pure Java implementation.

--- a/_impls/asyncssh.md
+++ b/_impls/asyncssh.md
@@ -1,14 +1,14 @@
 ---
 title: AsyncSSH
-homepage: http://asyncssh.readthedocs.io/
+homepage: https://asyncssh.readthedocs.io/
 source-repository: https://github.com/ronf/asyncssh
 license: "[EPL v2.0](https://www.eclipse.org/legal/epl-2.0/faq.php)"
 first-release:
     date: 2013-09-14
 latest-release:
-    version: 2.13.0
-    date: 2022-12-27
-changelog: http://asyncssh.readthedocs.io/en/latest/changes.html
+    version: 2.15.0
+    date: 2024-07-03
+changelog: https://asyncssh.readthedocs.io/en/latest/changes.html
 client: yes
 server: yes
 
@@ -118,6 +118,9 @@ protocols:
         - rsa2048-sha256                                # since 1.13.1
         - rsa1024-sha1                                  # since 1.13.1
         - ext-info-c                                    # since 1.7.0
+        - ext-info-s
+        - kex-strict-c-v00@openssh.com
+        - kex-strict-s-v00@openssh.com
     mac:
         - umac-64-etm@openssh.com                       # since 1.8.0
         - umac-128-etm@openssh.com                      # since 1.8.0
@@ -152,6 +155,7 @@ protocols:
         - keyboard-interactive
         - password
     extension:
+        - global-requests-ok
         - server-sig-algs                               # since 1.7.0
 
 first_kex_packet_follows: 1

--- a/_impls/openssh.md
+++ b/_impls/openssh.md
@@ -52,6 +52,8 @@ protocols:
         - ssh-ed25519-cert-v01@openssh.com  # since 6.5
         - ssh-rsa-cert-v01@openssh.com
         - ssh-dss-cert-v01@openssh.com      # disabled by default since 7.0
+        - rsa-sha2-256-cert-v01@openssh.com
+        - rsa-sha2-512-cert-v01@openssh.com
         #- ssh-rsa-cert-v00@openssh.com      # removed in 7.0
         #- ssh-dss-cert-v00@openssh.com      # removed in 7.0
         - ecdsa-sha2-nistp256               # since 5.7

--- a/_impls/paramiko.md
+++ b/_impls/paramiko.md
@@ -1,14 +1,14 @@
 ---
 title: Paramiko
-homepage: http://www.paramiko.org/
+homepage: https://www.paramiko.org/
 source-repository: https://github.com/paramiko/paramiko
 license: "[LGPL 2.1](https://github.com/paramiko/paramiko/blob/master/LICENSE)"
 first-release:
     date: 2003-09-13    # v0.1, according to NEWS file
 latest-release:
-    version: 2.0.0
-    date: 2016-04-28
-changelog: http://www.paramiko.org/changelog.html
+    version: 3.4.0
+    date: 2023-12-18
+changelog: https://www.paramiko.org/changelog.html
 client: yes
 server: yes
 library: both
@@ -19,12 +19,12 @@ protocols:
         - aes192-ctr            # since 1.16.0 (2015-11-04)
         - aes256-ctr
         - aes128-cbc
-        - blowfish-cbc
+        #- blowfish-cbc         # removed in 2.11.0
         - aes192-cbc            # since 1.16.0 (2015-11-04)
         - aes256-cbc
         - 3des-cbc
-        - arcfour128
-        - arcfour256
+        #- arcfour128           # removed in 2.1.3
+        #- arcfour256           # removed in 2.1.3
     compression:
         - zlib@openssh.com
         - zlib
@@ -35,14 +35,34 @@ protocols:
         - ecdsa-sha2-nistp256   # since 1.12.0 (2013-09-27)
         - ecdsa-sha2-nistp384   # since 2.0.0 (2016-04-28)
         - ecdsa-sha2-nistp521   # since 2.0.0 (2016-04-28)
+        - rsa-sha2-256
+        - rsa-sha2-512
+        - ssh-ed25519
+        - ssh-rsa-cert-v01@openssh.com
+        - ssh-dss-cert-v01@openssh.com
+        - ecdsa-sha2-nistp256-cert-v01@openssh.com
+        - ecdsa-sha2-nistp384-cert-v01@openssh.com
+        - ecdsa-sha2-nistp521-cert-v01@openssh.com
+        - rsa-sha2-256-cert-v01@openssh.com
+        - rsa-sha2-512-cert-v01@openssh.com
+        - ssh-ed25519-cert-v01@openssh.com
     kex:
         - diffie-hellman-group1-sha1
         - diffie-hellman-group14-sha1   # since 1.15.0 (2014-09-18)
+        - diffie-hellman-group14-sha256
+        - diffie-hellman-group16-sha512
         - diffie-hellman-group-exchange-sha1
         - diffie-hellman-group-exchange-sha256  # since 1.16.0 (2015-11-04)
+        - ecdh-sha2-nistp256
+        - ecdh-sha2-nistp384
+        - ecdh-sha2-nistp521
+        - curve25519-sha256@libssh.org
         - gss-group1-sha1-*     # since 1.15.0 (2014-09-18)
         - gss-group14-sha1-*    # since 1.15.0 (2014-09-18)
         - gss-gex-sha1-*        # since 1.15.0 (2014-09-18)
+        - ext-info-c
+        - kex-strict-c-v00@openssh.com
+        - kex-strict-s-v00@openssh.com
     mac:
         - hmac-sha2-256         # since 1.16.0 (2015-11-04)
         - hmac-sha2-512         # since 1.16.0 (2015-11-04)
@@ -50,12 +70,16 @@ protocols:
         - hmac-sha1-96
         - hmac-md5-96
         - hmac-sha1
+        - hmac-sha2-256-etm@openssh.com
+        - hmac-sha2-512-etm@openssh.com
     userauth:
         - publickey
         - password
         - keyboard-interactive
         - gssapi-with-mic       # since 1.15.0 (2014-09-18) # only OID 1.2.840.113554.1.2.2 / Kerberos
         - gssapi-keyex          # since 1.15.0 (2014-09-18)
+    extension:
+        - server-sig-algs
 ---
 * [Python](https://www.python.org/) library.
-* Built on [PyCrypto](http://pycrypto.org/), a Python C extension for low level cryptography.
+* Built on [pyca/cryptography](https://cryptography.io/).

--- a/_impls/putty.md
+++ b/_impls/putty.md
@@ -1,6 +1,6 @@
 ---
 title: PuTTY
-homepage: http://www.chiark.greenend.org.uk/~sgtatham/putty/
+homepage: https://www.chiark.greenend.org.uk/~sgtatham/putty/
 source-repository: git://git.tartarus.org/simon/putty.git
 license: "[MIT style](http://www.chiark.greenend.org.uk/~sgtatham/putty/licence.html)"
 first-release:
@@ -15,9 +15,9 @@ first-release:
 # the development code made its first successful SSH connection 1998-05-29.
 # So, all in all, this is why I give 1998 as date of the first release.
 latest-release:
-    version: 0.67
-    date: 2016-03-05
-changelog: http://www.chiark.greenend.org.uk/~sgtatham/putty/changes.html
+    version: 0.81
+    date: 2024-04-15
+changelog: https://www.chiark.greenend.org.uk/~sgtatham/putty/changes.html
 client: yes
 server: no
 platforms:
@@ -40,6 +40,8 @@ protocols:
         - arcfour256
         - blowfish-cbc
         - blowfish-ctr
+        - aes128-gcm@openssh.com
+        - aes256-gcm@openssh.com
         - chacha20-poly1305@openssh.com
     compression:
         - zlib
@@ -49,25 +51,62 @@ protocols:
         - ssh-rsa
         - ssh-dss
         - ssh-ed25519
+        - ssh-ed448
         - ecdsa-sha2-nistp256
         - ecdsa-sha2-nistp384
         - ecdsa-sha2-nistp521
+        - rsa-sha2-256
+        - rsa-sha2-512
+        - ssh-rsa-cert-v01@openssh.com
+        - ssh-dss-cert-v01@openssh.com
+        - ssh-ed25519-cert-v01@openssh.com
+        - ecdsa-sha2-nistp256-cert-v01@openssh.com
+        - ecdsa-sha2-nistp384-cert-v01@openssh.com
+        - ecdsa-sha2-nistp521-cert-v01@openssh.com
+        - rsa-sha2-256-cert-v01@openssh.com
+        - rsa-sha2-512-cert-v01@openssh.com
     kex:
         - diffie-hellman-group1-sha1
         - diffie-hellman-group14-sha1
+        - diffie-hellman-group14-sha256
+        - diffie-hellman-group15-sha512
+        - diffie-hellman-group16-sha512
+        - diffie-hellman-group17-sha512
+        - diffie-hellman-group18-sha512
         - diffie-hellman-group-exchange-sha256
         - diffie-hellman-group-exchange-sha1
+        - curve25519-sha256
+        - curve25519-sha256@libssh.org
+        - curve448-sha512
         - ecdh-sha2-nistp256
         - ecdh-sha2-nistp384
         - ecdh-sha2-nistp521
+        - sntrup761x25519-sha512@openssh.com
         - rsa1024-sha1
         - rsa2048-sha256
+        - gss-gex-sha1-*
+        - gss-group1-sha1-*
+        - gss-group14-sha1-*
+        - gss-group14-sha256-*
+        - gss-group15-sha512-*
+        - gss-group16-sha512-*
+        - gss-group17-sha512-*
+        - gss-group18-sha512-*
+        - gss-curve25519-sha256-*
+        - gss-nistp256-sha256-*
+        - gss-nistp384-sha384-*
+        - gss-nistp521-sha512-*
+        - ext-info-c
+        - kex-strict-c-v00@openssh.com
+        - kex-strict-s-v00@openssh.com
     mac:
         - hmac-md5
         - hmac-sha1
         - hmac-sha1-96
         - hmac-sha2-256
+        - hmac-sha2-512
         - hmac-sha2-256-etm@openssh.com
+        - hmac-sha2-512-etm@openssh.com
         - hmac-sha1-etm@openssh.com
         - hmac-sha1-96-etm@openssh.com
         - hmac-md5-etm@openssh.com
@@ -76,5 +115,8 @@ protocols:
         - password
         - keyboard-interactive
         - gssapi-with-mic
+        - gssapi-keyex
+    extension:
+        - server-sig-algs
 ---
 * [Wikipedia](https://en.wikipedia.org/wiki/PuTTY)

--- a/_impls/sshj.md
+++ b/_impls/sshj.md
@@ -7,8 +7,8 @@ license: "[Apache-2.0](https://github.com/hierynomus/sshj/blob/master/LICENSE)"
 #first-release:
 #    date: YYYY-MM-DD
 latest-release:
-    version: 0.26.0
-    date: 2018-07-24
+    version: 0.38.0
+    date: 2024-01-02
 #changelog: URL
 client: no
 server: no
@@ -18,13 +18,16 @@ protocols:
         - aes128-ctr
         - aes192-ctr
         - aes256-ctr
-        - aes128-cbc 
-        - aes192-cbc 
-        - aes256-cbc 
+        - aes128-cbc
+        - aes192-cbc
+        - aes256-cbc
+        - aes128-gcm@openssh.com
+        - aes256-gcm@openssh.com
         - 3des-ctr
         - 3des-cbc
         - blowfish-ctr
         - blowfish-cbc
+        - chacha20-poly1305@openssh.com
         - twofish128-ctr
         - twofish192-ctr
         - twofish256-ctr
@@ -68,8 +71,14 @@ protocols:
         - ecdsa-sha2-nistp384
         - ecdsa-sha2-nistp521
         - ssh-ed25519
+        - rsa-sha2-256
+        - rsa-sha2-512
         - ssh-rsa-cert-v01@openssh.com
         - ssh-dss-cert-v01@openssh.com
+        - ecdsa-sha2-nistp256-cert-v01@openssh.com
+        - ecdsa-sha2-nistp384-cert-v01@openssh.com
+        - ecdsa-sha2-nistp521-cert-v01@openssh.com
+        - ssh-ed25519-cert-v01@openssh.com
     kex:
         - curve25519-sha256
         - curve25519-sha256@libssh.org
@@ -93,6 +102,9 @@ protocols:
         - diffie-hellman-group17-sha512
         - diffie-hellman-group18-sha512
         - diffie-hellman-group18-sha512@ssh.com
+        - ext-info-c
+        - kex-strict-c-v00@openssh.com
+        - kex-strict-s-v00@openssh.com
     mac:
         - hmac-sha1
         - hmac-sha1-96
@@ -102,6 +114,13 @@ protocols:
         - hmac-sha2-512
         - hmac-ripemd160
         - hmac-ripemd160@openssh.com
+        - hmac-md5-etm@openssh.com
+        - hmac-md5-96-etm@openssh.com
+        - hmac-sha1-etm@openssh.com
+        - hmac-sha1-96-etm@openssh.com
+        - hmac-sha2-256-etm@openssh.com
+        - hmac-sha2-512-etm@openssh.com
+        - hmac-ripemd160-etm@openssh.com
     userauth:
         - publickey
         - password


### PR DESCRIPTION
- Update Paramiko to 3.4.0
- Update AsyncSSH to 2.15.0
- Update Apache SSHD to 2.13.1
- Update SSHJ to 0.38.0
- Add missing rsa-sha2-256-cert-v01@openssh.com & rsa-sha2-512-cert-v01@openssh.com to OpenSSH
- Update PuTTY to 0.81