### PR TITLE
Add RFC 8732, RFC 9519 & add missing extensions supported by Apache SSHD

### DIFF
--- a/_data/specs.yml
+++ b/_data/specs.yml
@@ -127,6 +127,7 @@ rfc4345:
 rfc4419:
     name: RFC 4419
     url: https://tools.ietf.org/html/rfc4419
+    errata: https://www.rfc-editor.org/errata_search.php?rfc=4419
     title: "Diffie-Hellman Group Exchange for the SSH Transport Layer Protocol"
     protocols:
         kex:
@@ -224,11 +225,13 @@ rfc6187:
 rfc6239:
     name: RFC 6239
     url: https://tools.ietf.org/html/rfc6594
+    errata: https://www.rfc-editor.org/errata_search.php?rfc=6239
     title: "Suite B Cryptographic Suites for SSH"
 
 rfc6594:
     name: RFC 6594
     url: https://tools.ietf.org/html/rfc6594
+    errata: https://www.rfc-editor.org/errata_search.php?rfc=6594
     title: "Use of the SHA-256 Algorithm with RSA, DSA, and ECDSA in SSHFP Resource Records"
 
 rfc6668:
@@ -301,6 +304,7 @@ rfc8332:
 rfc8709:
     name: RFC 8709
     url: https://tools.ietf.org/html/rfc8709
+    errata: https://www.rfc-editor.org/errata_search.php?rfc=8709
     title: "Ed25519 and Ed448 Public Key Algorithms for the Secure Shell (SSH) Protocol"
     protocols:
         hostkey:
@@ -341,6 +345,7 @@ rfc8758:
 rfc9142:
     name: RFC 9142
     url: https://tools.ietf.org/html/rfc9142
+    errata: https://www.rfc-editor.org/errata_search.php?rfc=9142
     title: "Key Exchange (KEX) Method Updates and Recommendations for Secure Shell (SSH)"
 
 rfc9212:

--- a/_data/specs.yml
+++ b/_data/specs.yml
@@ -348,6 +348,11 @@ rfc9212:
     url: https://tools.ietf.org/html/rfc9212
     title: "Commercial National Security Algorithm (CNSA) Suite Cryptography for Secure Shell (SSH)"
 
+rfc9519:
+    name: RFC 9519
+    url: https://tools.ietf.org/html/rfc9519
+    title: "Update to the IANA SSH Protocol Parameters Registry Requirements"
+
 draft-ietf-secsh-x509-03:
     name: draft-ietf-secsh-x509-03
     url: https://tools.ietf.org/html/draft-ietf-secsh-x509-03

--- a/_data/specs.yml
+++ b/_data/specs.yml
@@ -456,6 +456,8 @@ openssh:
             - kex-strict-c-v00@openssh.com
             - kex-strict-s-v00@openssh.com
             - sntrup761x25519-sha512@openssh.com # see also https://www.openssh.com/txt/release-9.0
+        userauth:
+            - publickey-hostbound-v00@openssh.com
         extension:
             - ext-info-in-auth@openssh.com
             - ping@openssh.com

--- a/_data/specs.yml
+++ b/_data/specs.yml
@@ -268,11 +268,6 @@ rfc8268:
             - diffie-hellman-group16-sha512 # draft-ietf-curdle-ssh-kex-sha2: SHOULD
             - diffie-hellman-group17-sha512 # draft-ietf-curdle-ssh-kex-sha2: MAY
             - diffie-hellman-group18-sha512 # draft-ietf-curdle-ssh-kex-sha2: MAY
-            - gss-group14-sha256-*          # draft-ietf-curdle-ssh-kex-sha2: SHOULD
-            - gss-group15-sha512-*          # draft-ietf-curdle-ssh-kex-sha2: MAY
-            - gss-group16-sha512-*          # draft-ietf-curdle-ssh-kex-sha2: SHOULD
-            - gss-group17-sha512-*          # draft-ietf-curdle-ssh-kex-sha2: MAY
-            - gss-group18-sha512-*          # draft-ietf-curdle-ssh-kex-sha2: MAY
 
 rfc8270:
     name: RFC 8270
@@ -320,6 +315,23 @@ rfc8731:
         kex:
             - curve25519-sha256 # draft-ietf-curdle-ssh-kex-sha2: SHOULD
             - curve448-sha512   # draft-ietf-curdle-ssh-kex-sha2: MAY
+
+rfc8732:
+    name: RFC 8732
+    url: https://tools.ietf.org/html/rfc8732
+    title: "Generic Security Service Application Program Interface (GSS-API) Key Exchange with SHA-2"
+    protocols:
+        kex:
+            - gss-group14-sha256-*          # draft-ietf-curdle-ssh-kex-sha2: SHOULD
+            - gss-group15-sha512-*          # draft-ietf-curdle-ssh-kex-sha2: MAY
+            - gss-group16-sha512-*          # draft-ietf-curdle-ssh-kex-sha2: SHOULD
+            - gss-group17-sha512-*          # draft-ietf-curdle-ssh-kex-sha2: MAY
+            - gss-group18-sha512-*          # draft-ietf-curdle-ssh-kex-sha2: MAY
+            - gss-nistp256-sha256-*
+            - gss-nistp384-sha384-*
+            - gss-nistp521-sha512-*
+            - gss-curve25519-sha256-*
+            - gss-curve448-sha512-*
 
 rfc8758:
     name: RFC 8758

--- a/_impls/apache-sshd.md
+++ b/_impls/apache-sshd.md
@@ -83,6 +83,7 @@ protocols:
         - publickey
         - gssapi-with-mic           # only OID 1.2.840.113554.1.2.2 / Kerberos
         - hostbased
+        - publickey-hostbound-v00@openssh.com
     extension:
         - publickey-hostbound@openssh.com
         - server-sig-algs

--- a/_impls/apache-sshd.md
+++ b/_impls/apache-sshd.md
@@ -83,5 +83,8 @@ protocols:
         - publickey
         - gssapi-with-mic           # only OID 1.2.840.113554.1.2.2 / Kerberos
         - hostbased
+    extension:
+        - publickey-hostbound@openssh.com
+        - server-sig-algs
 ---
 * Pure Java implementation.

--- a/_impls/dropbear.md
+++ b/_impls/dropbear.md
@@ -1,13 +1,13 @@
 ---
 title: Dropbear
 homepage: https://matt.ucc.asn.au/dropbear/dropbear.html
-source-repository: https://secure.ucc.asn.au/hg/dropbear/
-license: "[MIT style](https://secure.ucc.asn.au/hg/dropbear/raw-file/tip/LICENSE)"
+source-repository: https://github.com/mkj/dropbear
+license: "[MIT style](https://github.com/mkj/dropbear/blob/master/LICENSE)"
 first-release:
     date: 2003-04-06    # according to CHANGES file
 latest-release:
-    version: 2022.82
-    date: 2022-04-01
+    version: 2024.85
+    date: 2024-04-25
 changelog: https://matt.ucc.asn.au/dropbear/CHANGES
 client: yes
 server: yes
@@ -37,7 +37,7 @@ protocols:
         - ecdsa-sha2-nistp521
         - ssh-rsa
         - rsa-sha2-256                   # since 2022.82
-        - ssh-dss
+        # - ssh-dss                      # disabled by default since 2022.83
         - ssh-ed25519                    # since 2020.79
         - sk-ssh-ed25519@openssh.com     # since 2022.82
         - sk-ecdsa-sha2-nistp256@openssh.com     # since 2022.82
@@ -52,17 +52,23 @@ protocols:
         # - diffie-hellman-group16-sha512   # since 2018.76. disabled by default
         # - diffie-hellman-group1-sha1    # disabled by default
         - kexguess2@matt.ucc.asn.au     # Dropbear extension (only documented in their CHANGES file?)
+        - ext-info-c
+        - kex-strict-c-v00@openssh.com
+        - kex-strict-s-v00@openssh.com
     mac:
         # - hmac-sha1-96   # disabled by default
         - hmac-sha1
         - hmac-sha2-256
+        # - hmac-sha2-512  # disabled by default
     userauth:
         - publickey
         - password
         - keyboard-interactive
+    extension:
+        - server-sig-algs
 
 first_kex_packet_follows: 1
-ident: "SSH-2.0-dropbear_2022.82"
+ident: "SSH-2.0-dropbear_2024.85"
 ---
 * Server and client for POSIX-based platforms.
 * [Wikipedia](https://en.wikipedia.org/wiki/Dropbear_%28software%29)

--- a/_impls/openssh.md
+++ b/_impls/openssh.md
@@ -110,6 +110,7 @@ protocols:
         - keyboard-interactive
         - gssapi-with-mic
         - hostbased
+        - publickey-hostbound-v00@openssh.com
     extension:
         - ext-info-in-auth@openssh.com      # since 9.6
         - ping@openssh.com                  # since 9.5


### PR DESCRIPTION
- Add RFC 8732
-- This also relocates the GSS SHA2 type KEX algorithms, as they are not defined in RFC 8268, but rather RFC 8732.
- Add RFC 9519
- Add missing extensions supported by Apache SSHD
- Update Dropbear to 2024.85
- Add additional RFC errata
- Document publickey-hostbound-v00@openssh.com userauth support in OpenSSH & Apache SSHD