### PR TITLE
Update libssh, libssh2, phpseclib, CycloneSSH, Net::SSH, SSH.NET, TinySSH, Erlang ssh library, Twisted Conch & Tera Term

### DIFF
--- a/_data/specs.yml
+++ b/_data/specs.yml
@@ -376,6 +376,24 @@ draft-ietf-secsh-filexfer-02:
     url: https://tools.ietf.org/html/draft-ietf-secsh-filexfer-02
     title: "SSH File Transfer Protocol [ expired 2002-04-01 ]"
 
+draft-josefsson-ntruprime-ssh-02:
+    name: draft-josefsson-ntruprime-ssh-02
+    url: https://tools.ietf.org/html/draft-josefsson-ntruprime-ssh-02.html
+    title: "Secure Shell (SSH) Key Exchange Method Using Hybrid Streamlined NTRU Prime sntrup761 and X25519 with SHA-512: sntrup761x25519-sha512 [ expired 2024-03-22 ]"
+    protocols:
+        kex:
+            - sntrup761x25519-sha512
+
+draft-kampanakis-curdle-ssh-pq-ke-02:
+    name: draft-kampanakis-curdle-ssh-pq-ke-02
+    url: https://tools.ietf.org/html/draft-kampanakis-curdle-ssh-pq-ke-02.html
+    title: "PQ/T Hybrid Key Exchange in SSH [ expired 2024-11-11 ]"
+    protocols:
+        kex:
+            - mlkem768nistp256-sha256
+            - mlkem1024nistp384-sha384
+            - mlkem768x25519-sha256
+
 draft-kanno-secsh-camellia-02:
     name: draft-kanno-secsh-camellia-02
     url: https://tools.ietf.org/html/draft-kanno-secsh-camellia-02

--- a/_impls/cyclonessh.md
+++ b/_impls/cyclonessh.md
@@ -6,8 +6,8 @@ license: "Dual license: [GPLv2](http://www.gnu.org/licenses/old-licenses/gpl-2.0
 first-release:
     date: 2019-07-19
 latest-release:
-    version: 2.3.0
-    date: 2023-06-12
+    version: 2.4.2
+    date: 2024-05-27
 changelog: https://www.oryx-embedded.com/download.html#changelog
 client: yes
 server: yes
@@ -79,7 +79,11 @@ protocols:
         - ssh-dss-cert-v01@openssh.com
         - ssh-dss
     kex:
+        - sntrup761x25519-sha512
         - sntrup761x25519-sha512@openssh.com
+        - mlkem768x25519-sha256
+        - mlkem768nistp256-sha256
+        - mlkem1024nistp384-sha384
         - curve25519-sha256
         - curve25519-sha256@libssh.org
         - curve448-sha512
@@ -102,6 +106,8 @@ protocols:
         - rsa1024-sha1
         - ext-info-c
         - ext-info-s
+        - kex-strict-c-v00@openssh.com
+        - kex-strict-s-v00@openssh.com
     mac:
         - hmac-sha2-256
         - hmac-sha2-256-etm@openssh.com
@@ -111,6 +117,7 @@ protocols:
         - hmac-sha1-etm@openssh.com
         - hmac-sha1-96
         - hmac-sha1-96-etm@openssh.com
+        - hmac-ripemd160
         - hmac-ripemd160@openssh.com
         - hmac-ripemd160-etm@openssh.com
         - hmac-md5

--- a/_impls/erlang.md
+++ b/_impls/erlang.md
@@ -1,14 +1,14 @@
 ---
 title: Erlang ssh library
-homepage: http://www.erlang.org/doc/man/ssh.html
+homepage: https://www.erlang.org/doc/apps/ssh/ssh.html
 source-repository: https://github.com/erlang/otp
 license: "[Apache-2.0](https://github.com/erlang/otp/blob/maint/LICENSE.txt)"
 first-release:
     date: 2005-10-25
 latest-release:
-    version: 4.7.3 (OTP 21.2.2)
-    date: 2018-12-28
-changelog: http://www.erlang.org/doc/apps/ssh/notes.html
+    version: 5.2.1 (OTP 27.0.1)
+    date: 2024-07-10
+changelog: https://www.erlang.org/doc/apps/ssh/notes.html
 client: yes
 server: yes
 library: both
@@ -18,11 +18,13 @@ protocols:
         - aes256-ctr                # since version 4.2
         - aes192-ctr                # since version 4.2
         - aes128-ctr
+        - aes256-cbc                # since version 4.8.1
+        - aes192-cbc                # since version 4.8.1
         - aes128-cbc
         - aes128-gcm@openssh.com    # since version 4.2
         - aes256-gcm@openssh.com    # since version 4.2
-        - AEAD_AES_128_GCM          # since version 4.2
-        - AEAD_AES_256_GCM          # since version 4.2
+        - AEAD_AES_128_GCM          # since version 4.2, disabled by default
+        - AEAD_AES_256_GCM          # since version 4.2, disabled by default
         - 3des-cbc
         - chacha20-poly1305@openssh.com # since version 4.7.1
     compression:
@@ -33,18 +35,18 @@ protocols:
         - ecdsa-sha2-nistp256   # since version 4.2
         - ecdsa-sha2-nistp384   # since version 4.2
         - ecdsa-sha2-nistp521   # since version 4.2
-        - ssh-ed25519
-        - ssh-ed448
-        - ssh-rsa
-        - ssh-dss
+        - ssh-ed25519           # since version 4.7.2
+        - ssh-ed448             # since version 4.7.2
+        - ssh-rsa               # disabled by default since 4.12
+        - ssh-dss               # disabled by default since 4.10
         - rsa-sha2-256              # since 4.5
         - rsa-sha2-512              # since 4.5
     kex:
         - ecdh-sha2-nistp256
         - ecdh-sha2-nistp384
-        - diffie-hellman-group14-sha1
+        - diffie-hellman-group14-sha1  # disabled by default since 4.10
         - diffie-hellman-group-exchange-sha256
-        - diffie-hellman-group-exchange-sha1
+        - diffie-hellman-group-exchange-sha1 # disabled by default since 4.10
         - ecdh-sha2-nistp521
         - diffie-hellman-group1-sha1   # disabled by default since 4.5
         - diffie-hellman-group14-sha256      # since 4.5
@@ -55,12 +57,18 @@ protocols:
         - curve25519-sha256@libssh.org       # since version 4.7.1
         - ext-info-c                         # since 4.5
         - ext-info-s                         # since 4.5
+        - kex-strict-c-v00@openssh.com
+        - kex-strict-s-v00@openssh.com
     mac:
         - hmac-sha2-256
         - hmac-sha2-512
         - hmac-sha1
-        - AEAD_AES_128_GCM     # since version 4.2
-        - AEAD_AES_256_GCM     # since version 4.2
+        - hmac-sha1-96         # since version 4.8.1, disabled by default
+        - AEAD_AES_128_GCM     # since version 4.2, disabled by default
+        - AEAD_AES_256_GCM     # since version 4.2, disabled by default
+        - hmac-sha2-256-etm@openssh.com # since version 4.10
+        - hmac-sha2-512-etm@openssh.com # since version 4.10
+        - hmac-sha1-etm@openssh.com     # since version 4.10
     userauth:
         - publickey
         - password

--- a/_impls/jsch.md
+++ b/_impls/jsch.md
@@ -11,6 +11,7 @@ latest-release:
 changelog: https://github.com/mwiede/jsch/blob/master/ChangeLog.md
 client: yes
 server: no
+library: client
 
 protocols:
     cipher:

--- a/_impls/libssh.md
+++ b/_impls/libssh.md
@@ -1,18 +1,18 @@
 ---
 title: libssh
-homepage: http://www.libssh.org/
-source-repository: http://git.libssh.org/projects/libssh.git
+homepage: https://www.libssh.org/
+source-repository: https://git.libssh.org/projects/libssh.git
 references:
-    - http://api.libssh.org/stable/
+    - https://api.libssh.org/stable/
 license: "[LGPL 2.1](https://git.libssh.org/projects/libssh.git/tree/COPYING)"
 first-release:
     date: 2003-09-03
 # Looking at the initial commit in the git repository, it contains
 # a CHANGELOG which contains the date of the initial release.
 latest-release:
-    version: 0.9.1
-    date: 2019-10-25
-changelog: https://git.libssh.org/projects/libssh.git/tree/ChangeLog
+    version: 0.10.6
+    date: 2023-12-18
+changelog: https://git.libssh.org/projects/libssh.git/tree/CHANGELOG
 client: yes
 server: yes
 library: both
@@ -55,6 +55,10 @@ protocols:
         - ssh-rsa-cert-v01@openssh.com
         - ssh-dss
         - ssh-dss-cert-v01@openssh.com
+        - sk-ssh-ed25519@openssh.com                  # since 0.10.0, server side only
+        - sk-ssh-ed25519-cert-v01@openssh.com         # since 0.10.0, server side only
+        - sk-ecdsa-sha2-nistp256@openssh.com          # since 0.10.0, server side only
+        - sk-ecdsa-sha2-nistp256-cert-v01@openssh.com # since 0.10.0, server side only
     kex:
         - curve25519-sha256
         - curve25519-sha256@libssh.org
@@ -63,10 +67,14 @@ protocols:
         - ecdh-sha2-nistp256
         - diffie-hellman-group18-sha512
         - diffie-hellman-group16-sha512
+        - diffie-hellman-group14-sha256
         - diffie-hellman-group-exchange-sha256
         - diffie-hellman-group-exchange-sha1
         - diffie-hellman-group14-sha1
         - diffie-hellman-group1-sha1
+        - ext-info-c
+        - kex-strict-c-v00@openssh.com
+        - kex-strict-s-v00@openssh.com
     mac:
         - hmac-sha2-512-etm@openssh.com
         - hmac-sha2-256-etm@openssh.com
@@ -80,6 +88,8 @@ protocols:
         - hostbased
         - keyboard-interactive
         - gssapi-with-mic
+    extension:
+        - server-sig-algs
 ---
 * Mulitplatform C library for clients and servers.
 * Not to be confused with the unrelated [libssh2](/impls/libssh2.html)

--- a/_impls/libssh2.md
+++ b/_impls/libssh2.md
@@ -1,14 +1,14 @@
 ---
 title: libssh2
-homepage: http://www.libssh2.org/
-source-repository: https://github.com/libssh2/libssh2/
-license: "[BSD style](http://www.libssh2.org/license.html)"
+homepage: https://libssh2.org/
+source-repository: https://github.com/libssh2/libssh2
+license: "[BSD style](https://libssh2.org/license.html)"
 first-release:
     date: 2004-12-08    # version 0.1, initial release, date from repository
 latest-release:
-    version: 1.7.0
-    date: 2016-02-23
-changelog: http://www.libssh2.org/changes.html
+    version: 1.11.0
+    date: 2023-05-30
+changelog: https://libssh2.org/changes.html
 client: yes
 server: no
 library: client
@@ -27,6 +27,8 @@ protocols:
         - arcfour
         - cast128-cbc
         - 3des-cbc
+        - aes128-gcm@openssh.com
+        - aes256-gcm@openssh.com
     compression:
         - zlib
         - zlib@openssh.com  # added in 1.4.3
@@ -34,11 +36,35 @@ protocols:
     hostkey:
         - ssh-rsa
         - ssh-dss
+        - rsa-sha2-256
+        - rsa-sha2-512
+        - ecdsa-sha2-nistp256
+        - ecdsa-sha2-nistp384
+        - ecdsa-sha2-nistp521
+        - ssh-ed25519
+        - sk-ecdsa-sha2-nistp256@openssh.com
+        - sk-ssh-ed25519@openssh.com
+        - ssh-rsa-cert-v01@openssh.com
+        - ecdsa-sha2-nistp256-cert-v01@openssh.com
+        - ecdsa-sha2-nistp384-cert-v01@openssh.com
+        - ecdsa-sha2-nistp521-cert-v01@openssh.com
+        - ssh-ed25519-cert-v01@openssh.com
+        - sk-ecdsa-sha2-nistp256-cert-v01@openssh.com
+        - sk-ssh-ed25519-cert-v01@openssh.com
     kex:
         - diffie-hellman-group14-sha1
         - diffie-hellman-group-exchange-sha1
         - diffie-hellman-group1-sha1
         - diffie-hellman-group-exchange-sha256
+        - diffie-hellman-group14-sha256
+        - diffie-hellman-group16-sha512
+        - diffie-hellman-group18-sha512
+        - ecdh-sha2-nistp256
+        - ecdh-sha2-nistp384
+        - ecdh-sha2-nistp521
+        - curve25519-sha256
+        - curve25519-sha256@libssh.org
+        - ext-info-c
     mac:
         - hmac-sha2-256
         - hmac-sha2-512
@@ -48,11 +74,16 @@ protocols:
         - hmac-md5-96
         - hmac-ripemd160
         - hmac-ripemd160@openssh.com
+        - hmac-sha2-256-etm@openssh.com
+        - hmac-sha2-512-etm@openssh.com
+        - hmac-sha1-etm@openssh.com
     userauth:
         - password
         - publickey
         - hostbased
         - keyboard-interactive
+    extension:
+        - server-sig-algs
 ---
 * C library for clients.
 * Not to be confused with the unrelated [libssh](/impls/libssh.html)

--- a/_impls/net-ssh.md
+++ b/_impls/net-ssh.md
@@ -6,8 +6,8 @@ license: "[MIT style](https://github.com/net-ssh/net-ssh/blob/master/LICENSE.txt
 #first-release:
 #    date: YYYY-MM-DD
 latest-release:
-    version: 6.0.2
-    date: 2020-04-25
+    version: 7.2.3
+    date: 2024-04-02
 changelog: https://github.com/net-ssh/net-ssh/blob/master/CHANGES.txt
 client: yes
 server: no
@@ -15,19 +15,20 @@ library: client
 
 protocols:
     cipher:
-        - 3des-cbc                      # deprecated in 6.0, will be removed in 7.0
-        - 3des-ctr                      # deprecated in 6.0, will be removed in 7.0
-        - aes128-cbc                    # deprecated in 6.0, will be removed in 7.0
-        - aes192-cbc                    # deprecated in 6.0, will be removed in 7.0
-        - aes256-cbc                    # deprecated in 6.0, will be removed in 7.0
+        - chacha20-poly1305@openssh.com
+        - 3des-cbc                      # deprecated in 6.0, will be removed in 8.0
+        - 3des-ctr                      # deprecated in 6.0, will be removed in 8.0
+        - aes128-cbc                    # deprecated in 6.0, will be removed in 8.0
+        - aes192-cbc                    # deprecated in 6.0, will be removed in 8.0
+        - aes256-cbc                    # deprecated in 6.0, will be removed in 8.0
         - aes128-ctr
         - aes192-ctr
         - aes256-ctr
         #- arcfour                      # removed in 6.0
         #- arcfour128                   # removed in 6.0
         #- arcfour256                   # removed in 6.0
-        - blowfish-cbc
-        - blowfish-ctr
+        - blowfish-cbc                  # deprecated in 6.0, will be removed in 8.0
+        - blowfish-ctr                  # deprecated in 6.0, will be removed in 8.0
         #- camellia128-cbc
         #- camellia128-cbc@openssh.org  # removed in 4.0
         #- camellia128-ctr              # removed in 4.0
@@ -40,11 +41,11 @@ protocols:
         #- camellia256-cbc@openssh.org  # removed in 4.0
         #- camellia256-ctr              # removed in 4.0
         #- camellia256-ctr@openssh.org  # removed in 4.0
-        - cast128-cbc                   # deprecated in 6.0, will be removed in 7.0
-        - cast128-ctr                   # deprecated in 6.0, will be removed in 7.0
-        - idea-cbc                      # deprecated in 6.0, will be removed in 7.0
-        - rijndael-cbc@lysator.liu.se   # deprecated in 6.0, will be removed in 7.0
-        #- none                         # deprecated in 6.0, will be removed in 7.0
+        - cast128-cbc                   # deprecated in 6.0, will be removed in 8.0
+        - cast128-ctr                   # deprecated in 6.0, will be removed in 8.0
+        - idea-cbc                      # deprecated in 6.0, will be removed in 8.0
+        - rijndael-cbc@lysator.liu.se   # deprecated in 6.0, will be removed in 8.0
+        #- none                         # deprecated in 6.0, will be removed in 8.0
     compression:
         - zlib
         - zlib@openssh.com
@@ -53,33 +54,41 @@ protocols:
         - ecdsa-sha2-nistp256
         - ecdsa-sha2-nistp384
         - ecdsa-sha2-nistp521
-        - ssh-dss   # deprecated in 6.0, will be removed in 7.0
+        - ssh-dss   # deprecated in 6.0, will be removed in 8.0
         - ssh-ed25519
         - ssh-rsa
+        - rsa-sha2-256
+        - rsa-sha2-512
+        - ecdsa-sha2-nistp256-cert-v01@openssh.com
+        - ecdsa-sha2-nistp384-cert-v01@openssh.com
+        - ecdsa-sha2-nistp521-cert-v01@openssh.com
+        - ssh-ed25519-cert-v01@openssh.com
         #- ssh-rsa-cert-v00@openssh.com
-        #- ssh-rsa-cert-v01@openssh.com
+        - ssh-rsa-cert-v01@openssh.com
+        - rsa-sha2-256-cert-v01@openssh.com
+        - rsa-sha2-512-cert-v01@openssh.com
     kex:
         - curve25519-sha256
-        - diffie-hellman-group-exchange-sha1    # deprecated in 6.0, will be removed in 7.0
+        - diffie-hellman-group-exchange-sha1    # deprecated in 6.0, will be removed in 8.0
         - diffie-hellman-group-exchange-sha256
-        - diffie-hellman-group1-sha1            # deprecated in 6.0, will be removed in 7.0
+        - diffie-hellman-group1-sha1            # deprecated in 6.0, will be removed in 8.0
         - diffie-hellman-group14-sha1
         - ecdh-sha2-nistp256
         - ecdh-sha2-nistp384
         - ecdh-sha2-nistp521
     mac:
-        - hmac-md5              # deprecated in 6.0, will be removed in 7.0
-        - hmac-md5-96           # deprecated in 6.0, will be removed in 7.0
-        - hmac-ripemd160        # deprecated in 6.0, will be removed in 7.0
+        - hmac-md5              # deprecated in 6.0, will be removed in 8.0
+        - hmac-md5-96           # deprecated in 6.0, will be removed in 8.0
+        - hmac-ripemd160        # deprecated in 6.0, will be removed in 8.0
         - hmac-sha1             # for backward compatibility
-        - hmac-sha1-96          # deprecated in 6.0, will be removed in 7.0
+        - hmac-sha1-96          # deprecated in 6.0, will be removed in 8.0
         - hmac-sha2-256
-        - hmac-sha2-256-96      # deprecated in 6.0, will be removed in 7.0
+        - hmac-sha2-256-96      # deprecated in 6.0, will be removed in 8.0
         - hmac-sha2-256-etm
         - hmac-sha2-512
-        - hmac-sha2-512-96      # deprecated in 6.0, will be removed in 7.0
+        - hmac-sha2-512-96      # deprecated in 6.0, will be removed in 8.0
         - hmac-sha2-512-etm
-        #- none                 # deprecated in 6.0, will be removed in 7.0
+        #- none                 # deprecated in 6.0, will be removed in 8.0
     userauth:
         - password
         - publickey

--- a/_impls/phpseclib.md
+++ b/_impls/phpseclib.md
@@ -1,22 +1,23 @@
 ---
 title: phpseclib
-homepage: http://phpseclib.sourceforge.net/
+homepage: https://phpseclib.com/
 source-repository: https://github.com/phpseclib/phpseclib
 license: "[MIT style](https://github.com/phpseclib/phpseclib/blob/master/LICENSE)"
 first-release:
     date: 2007-09-23
 latest-release:
-    version: 3.0.2
-    date: 2020-12-24
+    version: 3.0.39
+    date: 2024-06-24
 changelog: https://github.com/phpseclib/phpseclib/blob/master/CHANGELOG.md
-client: unknown
-server: unknown
+client: yes
+server: no
 library: client
 
 protocols:
     cipher:
         - aes128-gcm@openssh.com
         - aes256-gcm@openssh.com
+        - arcfour
         - arcfour256
         - arcfour128
         - aes128-ctr
@@ -39,6 +40,8 @@ protocols:
         - 3des-cbc
     compression:
         - none
+        - zlib
+        - zlib@openssh.com
     hostkey:
         - ssh-ed25519
         - ecdsa-sha2-nistp256
@@ -63,6 +66,9 @@ protocols:
         - diffie-hellman-group16-sha512
         - diffie-hellman_group17-sha512
         - diffie-hellman-group18-sha512
+        - ext-info-c
+        - kex-strict-c-v00@openssh.com
+        - kex-strict-s-v00@openssh.com
     mac:
         - hmac-sha2-256-etm@openssh.com
         - hmac-sha2-512-etm@openssh.com
@@ -81,5 +87,7 @@ protocols:
         - keyboard-interactive
         - publickey
         - password
+    extension:
+        - server-sig-algs
 ---
 * Pure PHP implementation.

--- a/_impls/ssh-net.md
+++ b/_impls/ssh-net.md
@@ -1,13 +1,13 @@
 ---
 title: SSH.NET
-homepage: https://github.com/sshnet/SSH.NET/
-source-repository: https://github.com/sshnet/SSH.NET.git
+homepage: https://sshnet.github.io/SSH.NET/
+source-repository: https://github.com/sshnet/SSH.NET
 license: "[MIT license](https://github.com/sshnet/SSH.NET/blob/develop/LICENSE)"
 first-release:
     date: 2010-09-16
 latest-release:
-    version: 2020.0.2-pre
-    date: 2020-05-29
+    version: 2024.1.0
+    date: 2024-06-28
 changelog: https://github.com/sshnet/SSH.NET/releases
 client: yes
 server: no
@@ -31,13 +31,18 @@ protocols:
         - cast128-cbc
         - aes128-ctr
         - aes192-ctr
+        - aes128-gcm@openssh.com
+        - aes256-gcm@openssh.com
     compression:
         - none
+        - zlib@openssh.com
     hostkey:
         - ssh-ed25519
         - ecdsa-sha2-nistp256
         - ecdsa-sha2-nistp384
         - ecdsa-sha2-nistp521
+        - rsa-sha2-512
+        - rsa-sha2-256
         - ssh-rsa
         - ssh-dss
     kex:
@@ -52,6 +57,8 @@ protocols:
         - diffie-hellman-group14-sha256
         - diffie-hellman-group14-sha1
         - diffie-hellman-group1-sha1
+        - kex-strict-c-v00@openssh.com
+        - kex-strict-s-v00@openssh.com
     mac:
         - hmac-md5
         - hmac-md5-96
@@ -61,12 +68,19 @@ protocols:
         - hmac-sha2-256-96
         - hmac-sha2-512
         - hmac-sha2-512-96
-        - hmac-ripemd160
-        - hmac-ripemd160@openssh.com
+        #- hmac-ripemd160                # removed in 2024.0.0
+        #- hmac-ripemd160@openssh.com    # removed in 2024.0.0
+        - hmac-sha2-256-etm@openssh.com
+        - hmac-sha2-512-etm@openssh.com
+        - hmac-sha1-etm@openssh.com
+        - hmac-sha1-96-etm@openssh.com
+        - hmac-md5-etm@openssh.com
+        - hmac-md5-96-etm@openssh.com
     userauth:
         - publickey
         - password
         - keyboard-interactive
+        - hostbased
 ---
 * Library for .NET.
 * Supports SFTP, SCP

--- a/_impls/sshj.md
+++ b/_impls/sshj.md
@@ -10,7 +10,7 @@ latest-release:
     version: 0.38.0
     date: 2024-01-02
 #changelog: URL
-client: no
+client: yes
 server: no
 library: client
 protocols:

--- a/_impls/tinyssh.md
+++ b/_impls/tinyssh.md
@@ -1,15 +1,15 @@
 ---
 title: TinySSH
-homepage: http://tinyssh.org/
+homepage: https://tinyssh.org/
 source-repository: https://github.com/janmojzis/tinyssh
-license: "[Public domain](http://tinyssh.org/LICENCE)"
+license: "[CC0](https://tinyssh.org/LICENCE)"
 first-release:
     date: 2014-02-16    # according to Wikipedia
     # see also https://news.ycombinator.com/item?id=7727738 from May 11, 2014
     # and http://tuxdiary.com/2014/05/11/tinyssh/
 latest-release:
-    #version: X.Y
-    date: 2022-03-11
+    version: 20240101
+    date: 2024-01-01
 changelog: https://github.com/janmojzis/tinyssh/releases
 client: no
 server: yes
@@ -28,6 +28,8 @@ protocols:
         #- ecdh-sha2-nistp256                       # removed in 20190101
         #- sntrup4591761x25519-sha512@tinyssh.org   # added in 20190101, removed in 20210319
         - sntrup761x25519-sha512@openssh.com        # added in 20210319
+        - kex-strict-c-v00@openssh.com
+        - kex-strict-s-v00@openssh.com
     mac:
         #- chacha20-poly1305@openssh.com    # not an actual allowed MAC value, but implied by the choice of cipher
         - hmac-sha2-256

--- a/_impls/ttssh2.md
+++ b/_impls/ttssh2.md
@@ -1,14 +1,14 @@
 ---
 title: Tera Term
-homepage: https://ttssh2.osdn.jp/
-source-repository: https://en.osdn.jp/projects/ttssh2/scm/svn/
-license: "[BSD style](http://ttssh2.osdn.jp/manual/en/about/copyright.html)"
+homepage: https://teratermproject.github.io/index-en.html
+source-repository: https://github.com/TeraTermProject/teraterm
+license: "[BSD style](https://teratermproject.github.io/manual/5/en/about/copyright.html)"
 first-release:
     date: 2004    # according to Wikipedia
 latest-release:
-    version: 4.89
-    date: 2015-12-01
-#changelog: TODO
+    version: 5.2
+    date: 2024-02-28
+changelog: https://teratermproject.github.io/manual/5/en/about/history.html
 client: yes
 server: no
 library: no
@@ -38,6 +38,9 @@ protocols:
         - camellia128-ctr
         - camellia192-ctr
         - camellia256-ctr
+        - aes128-gcm@openssh.com
+        - aes256-gcm@openssh.com
+        - chacha20-poly1305@openssh.com
     compression:
         - zlib
         - zlib@openssh.com
@@ -49,6 +52,8 @@ protocols:
         - ecdsa-sha2-nistp384
         - ecdsa-sha2-nistp521
         - ssh-ed25519
+        - rsa-sha2-256
+        - rsa-sha2-512
     kex:
         - diffie-hellman-group1-sha1
         - diffie-hellman-group14-sha1
@@ -60,6 +65,9 @@ protocols:
         - diffie-hellman-group14-sha256
         - diffie-hellman-group15-sha256
         - diffie-hellman-group16-sha256
+        - ext-info-c
+        - kex-strict-c-v00@openssh.com
+        - kex-strict-s-v00@openssh.com
     mac:
         - hmac-sha1
         - hmac-md5
@@ -68,11 +76,20 @@ protocols:
         - hmac-ripemd160@openssh.com
         - hmac-sha2-256
         - hmac-sha2-512
+        - hmac-sha1-etm@openssh.com
+        - hmac-md5-etm@openssh.com
+        - hmac-sha1-96-etm@openssh.com
+        - hmac-md5-96-etm@openssh.com
+        - hmac-ripemd160-etm@openssh.com
+        - hmac-sha2-256-etm@openssh.com
+        - hmac-sha2-512-etm@openssh.com
     userauth:
         - password
         - publickey
         - keyboard-interactive
+    extension:
+        - server-sig-algs
 
-ident: "SSH-2.0-TTSSH/2.75 Win32"
+ident: "SSH-2.0-TTSSH/3.2 Win32"
 ---
 * [Wikipedia page](https://en.wikipedia.org/wiki/Tera_Term)

--- a/_impls/twisted.md
+++ b/_impls/twisted.md
@@ -6,12 +6,12 @@ license: "[MIT](https://github.com/twisted/twisted/blob/trunk/LICENSE)"
 first-release:
     date: 2002-07-07    # Conch renamed from twisted.secsh
 latest-release:
-    version: 2022.10.0
-    date: 2022-10-31
+    version: 2024.3.0
+    date: 2024-03-01
 changelog: https://github.com/twisted/twisted/blob/trunk/NEWS.rst
-client: no
-server: no
-library: yes (client and server)
+client: yes
+server: yes
+library: both
 platforms:
     - linux
     - windows
@@ -56,13 +56,16 @@ protocols:
         - ecdh-sha2-nistp256
         - ecdh-sha2-nistp384
         - ecdh-sha2-nistp521
+        - ext-info-c
+        - ext-info-s
     # https://github.com/twisted/twisted/blob/2a33824557ed65d2241a51d6bba07ac76521b50f/src/twisted/conch/ssh/transport.py#L110
     mac:
         - hmac-md5
         - hmac-sha1
         - hmac-sha2-256
-        - hmac-sha2-348
+        - hmac-sha2-384
         - hmac-sha2-512
+        - none
     userauth:
         - publickey
         - password
@@ -71,7 +74,7 @@ protocols:
         - server-sig-algs                   # since 22.4.0
 
 first_kex_packet_follows: 1
-ident: "SSH-2.0-Twisted_2022.10.0"
+ident: "SSH-2.0-Twisted_2024.3.0"
 ---
 * Designed as a [Python](https://www.python.org/) library.
 * Cryptograpy provided by [cryptography](https://cryptography.io/) library, that provides bindings for [OpenSSL](https://www.openssl.org/) or [LibreSSL](https://www.libressl.org/)


### PR DESCRIPTION
- Update libssh to 0.10.6
- Update libssh2 to 1.11.0
- Update phpseclib to 3.0.39
- Denote JSch as a client library
- Denote SSHJ as a client implementation
- Update CycloneSSH to 2.4.2
- Update Net::SSH to 7.2.3
- Update SSH.NET to 2024.1.0
- Update TinySSH to 20240101
- Update Erlang ssh library to 5.2.1
- Update Twisted Conch to 2024.3.0
- Update Tera Term to 5.2