### PR TITLE
Correct name of gss-nistp384-sha384-* for AsyncSSH & add commercial license note for wolfSSH

### DIFF
--- a/_impls/asyncssh.md
+++ b/_impls/asyncssh.md
@@ -79,7 +79,7 @@ protocols:
         - gss-curve25519-sha256-*                       # since 1.18.0
         - gss-curve448-sha512-*                         # since 1.18.0
         - gss-nistp521-sha512-*                         # since 1.18.0
-        - gss-nistp384-sha256-*                         # since 1.18.0
+        - gss-nistp384-sha384-*                         # since 1.18.0
         - gss-nistp256-sha256-*                         # since 1.18.0
         - gss-13.3.132.0.10-sha256-*                    # since 1.18.0
         - gss-gex-sha256-*                              # since 1.9.0

--- a/_impls/wolfssh.md
+++ b/_impls/wolfssh.md
@@ -2,7 +2,7 @@
 title: wolfSSH
 homepage: https://www.wolfssl.com/products/wolfssh/
 source-repository: https://github.com/wolfSSL/wolfssh
-license: "[GPLv3](https://github.com/wolfSSL/wolfssh/blob/master/LICENSING)"
+license: "Dual license: [GPLv3](https://github.com/wolfSSL/wolfssh/blob/master/LICENSING) or [commercial](https://www.wolfssl.com/license/)"
 first-release:
     date: 2016-10-24
 latest-release:


### PR DESCRIPTION
- Correct name of gss-nistp384-sha384-* for AsyncSSH
- Add commercial license note for wolfSSH