### PR TITLE
Update to latest versions

### DIFF
--- a/_data/specs.yml
+++ b/_data/specs.yml
@@ -376,10 +376,18 @@ draft-ietf-secsh-filexfer-02:
     url: https://tools.ietf.org/html/draft-ietf-secsh-filexfer-02
     title: "SSH File Transfer Protocol [ expired 2002-04-01 ]"
 
-draft-josefsson-ntruprime-ssh-03:
-    name: draft-josefsson-ntruprime-ssh-03
-    url: https://tools.ietf.org/html/draft-josefsson-ntruprime-ssh-03.html
-    title: "Secure Shell (SSH) Key Exchange Method Using Hybrid Streamlined NTRU Prime sntrup761 and X25519 with SHA-512: sntrup761x25519-sha512 [ expired 2025-02-18 ]"
+draft-ietf-sshm-chacha20-poly1305-00:
+    name: draft-ietf-sshm-chacha20-poly1305-00
+    url: https://tools.ietf.org/html/draft-ietf-sshm-chacha20-poly1305-00.html
+    title: "Secure Shell (SSH) authenticated encryption cipher: chacha20-poly1305 [ expired 2025-07-10 ]"
+    protocols:
+        cipher:
+            - chacha20-poly1305
+
+draft-ietf-sshm-ntruprime-ssh-01:
+    name: draft-ietf-sshm-ntruprime-ssh-01
+    url: https://datatracker.ietf.org/doc/html/draft-ietf-sshm-ntruprime-ssh-01.html
+    title: "Secure Shell (SSH) Key Exchange Method Using Hybrid Streamlined NTRU Prime sntrup761 and X25519 with SHA-512: sntrup761x25519-sha512 [ expired 2025-06-12 ]"
     protocols:
         kex:
             - sntrup761x25519-sha512
@@ -395,10 +403,10 @@ draft-kampanakis-curdle-ssh-pq-ke-01:
             - ecdh-nistp521-kyber-1024r3-sha512-d00@openquantumsafe.org
             - x25519-kyber-512r3-sha256-d00@amazon.com
 
-draft-kampanakis-curdle-ssh-pq-ke-04:
-    name: draft-kampanakis-curdle-ssh-pq-ke-04
-    url: https://tools.ietf.org/html/draft-kampanakis-curdle-ssh-pq-ke-04.html
-    title: "PQ/T Hybrid Key Exchange in SSH [ expired 2025-02-25 ]"
+draft-kampanakis-curdle-ssh-pq-ke-05:
+    name: draft-kampanakis-curdle-ssh-pq-ke-05
+    url: https://tools.ietf.org/html/draft-kampanakis-curdle-ssh-pq-ke-05.html
+    title: "PQ/T Hybrid Key Exchange in SSH [ expired 2025-06-08 ]"
     protocols:
         kex:
             - mlkem768nistp256-sha256

--- a/_impls/apache-sshd.md
+++ b/_impls/apache-sshd.md
@@ -6,8 +6,8 @@ license: "[Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0)"
 first-release:
     date: 2009      # according to Wikipedia
 latest-release:
-    version: 2.13.2
-    date: 2024-08-09
+    version: 2.14.0
+    date: 2024-10-04
 changelog: "https://github.com/apache/mina-sshd/blob/master/CHANGES.md"
 client: yes
 server: yes
@@ -66,6 +66,7 @@ protocols:
         - curve25519-sha256
         - curve25519-sha256@libssh.org
         - curve448-sha512
+        - sntrup761x25519-sha512
         - sntrup761x25519-sha512@openssh.com
     mac:
         - hmac-md5

--- a/_impls/asyncssh.md
+++ b/_impls/asyncssh.md
@@ -6,8 +6,8 @@ license: "[EPL v2.0](https://www.eclipse.org/legal/epl-2.0/faq.php)"
 first-release:
     date: 2013-09-14
 latest-release:
-    version: 2.18.0
-    date: 2024-10-26
+    version: 2.19.0
+    date: 2024-12-12
 changelog: https://asyncssh.readthedocs.io/en/latest/changes.html
 client: yes
 server: yes

--- a/_impls/dropbear.md
+++ b/_impls/dropbear.md
@@ -6,8 +6,8 @@ license: "[MIT style](https://github.com/mkj/dropbear/blob/master/LICENSE)"
 first-release:
     date: 2003-04-06    # according to CHANGES file
 latest-release:
-    version: 2024.85
-    date: 2024-04-25
+    version: 2024.86
+    date: 2024-10-22
 changelog: https://matt.ucc.asn.au/dropbear/CHANGES
 client: yes
 server: yes

--- a/_impls/erlang.md
+++ b/_impls/erlang.md
@@ -6,8 +6,8 @@ license: "[Apache-2.0](https://github.com/erlang/otp/blob/maint/LICENSE.txt)"
 first-release:
     date: 2005-10-25
 latest-release:
-    version: 5.2.2 (OTP 27.1)
-    date: 2024-09-19
+    version: 5.2.5 (OTP 27.2)
+    date: 2024-12-11
 changelog: https://www.erlang.org/doc/apps/ssh/notes.html
 client: yes
 server: yes

--- a/_impls/jsch.md
+++ b/_impls/jsch.md
@@ -6,8 +6,8 @@ license: "[BSD style](https://github.com/mwiede/jsch/blob/master/LICENSE.txt)"
 #first-release:
 #    date: YYYY-MM-DD
 latest-release:
-    version: 0.2.22
-    date: 2025-01-09
+    version: 0.2.23
+    date: 2025-01-26
 changelog: https://github.com/mwiede/jsch/blob/master/ChangeLog.md
 client: yes
 server: no

--- a/_impls/jsch.md
+++ b/_impls/jsch.md
@@ -6,8 +6,8 @@ license: "[BSD style](https://github.com/mwiede/jsch/blob/master/LICENSE.txt)"
 #first-release:
 #    date: YYYY-MM-DD
 latest-release:
-    version: 0.2.20
-    date: 2024-09-17
+    version: 0.2.22
+    date: 2025-01-09
 changelog: https://github.com/mwiede/jsch/blob/master/ChangeLog.md
 client: yes
 server: no
@@ -90,6 +90,10 @@ protocols:
         - ext-info-s
         - kex-strict-c-v00@openssh.com
         - kex-strict-s-v00@openssh.com
+        - mlkem768x25519-sha256
+        - mlkem768nistp256-sha256
+        - mlkem1024nistp384-sha384
+        - sntrup761x25519-sha512
         - sntrup761x25519-sha512@openssh.com
     mac:
         - hmac-md5

--- a/_impls/libssh2.md
+++ b/_impls/libssh2.md
@@ -6,8 +6,8 @@ license: "[BSD style](https://libssh2.org/license.html)"
 first-release:
     date: 2004-12-08    # version 0.1, initial release, date from repository
 latest-release:
-    version: 1.11.0
-    date: 2023-05-30
+    version: 1.11.1
+    date: 2024-10-16
 changelog: https://libssh2.org/changes.html
 client: yes
 server: no
@@ -29,13 +29,14 @@ protocols:
         - 3des-cbc
         - aes128-gcm@openssh.com
         - aes256-gcm@openssh.com
+        - chacha20-poly1305@openssh.com # added in 1.11.1
     compression:
         - zlib
         - zlib@openssh.com  # added in 1.4.3
         - none
     hostkey:
         - ssh-rsa
-        - ssh-dss
+        - ssh-dss                                     # disabled by default since 1.11.1
         - rsa-sha2-256
         - rsa-sha2-512
         - ecdsa-sha2-nistp256
@@ -45,6 +46,8 @@ protocols:
         - sk-ecdsa-sha2-nistp256@openssh.com
         - sk-ssh-ed25519@openssh.com
         - ssh-rsa-cert-v01@openssh.com
+        - rsa-sha2-256-cert-v01@openssh.com           # added in 1.11.1
+        - rsa-sha2-512-cert-v01@openssh.com           # added in 1.11.1
         - ecdsa-sha2-nistp256-cert-v01@openssh.com
         - ecdsa-sha2-nistp384-cert-v01@openssh.com
         - ecdsa-sha2-nistp521-cert-v01@openssh.com
@@ -65,6 +68,8 @@ protocols:
         - curve25519-sha256
         - curve25519-sha256@libssh.org
         - ext-info-c
+        - kex-strict-c-v00@openssh.com         # added in 1.11.1
+        - kex-strict-s-v00@openssh.com         # added in 1.11.1
     mac:
         - hmac-sha2-256
         - hmac-sha2-512

--- a/_impls/net-ssh.md
+++ b/_impls/net-ssh.md
@@ -6,8 +6,8 @@ license: "[MIT style](https://github.com/net-ssh/net-ssh/blob/master/LICENSE.txt
 #first-release:
 #    date: YYYY-MM-DD
 latest-release:
-    version: 7.2.3
-    date: 2024-04-02
+    version: 7.3.0
+    date: 2024-10-02
 changelog: https://github.com/net-ssh/net-ssh/blob/master/CHANGES.txt
 client: yes
 server: no
@@ -15,6 +15,8 @@ library: client
 
 protocols:
     cipher:
+        - aes128-gcm@openssh.com
+        - aes256-gcm@openssh.com
         - chacha20-poly1305@openssh.com
         - 3des-cbc                      # deprecated in 6.0, will be removed in 8.0
         - 3des-ctr                      # deprecated in 6.0, will be removed in 8.0

--- a/_impls/phpseclib.md
+++ b/_impls/phpseclib.md
@@ -6,8 +6,8 @@ license: "[MIT style](https://github.com/phpseclib/phpseclib/blob/master/LICENSE
 first-release:
     date: 2007-09-23
 latest-release:
-    version: 3.0.42
-    date: 2024-09-15
+    version: 3.0.43
+    date: 2024-12-14
 changelog: https://github.com/phpseclib/phpseclib/blob/master/CHANGELOG.md
 client: yes
 server: no

--- a/_impls/putty.md
+++ b/_impls/putty.md
@@ -15,8 +15,8 @@ first-release:
 # the development code made its first successful SSH connection 1998-05-29.
 # So, all in all, this is why I give 1998 as date of the first release.
 latest-release:
-    version: 0.81
-    date: 2024-04-15
+    version: 0.82
+    date: 2024-11-27
 changelog: https://www.chiark.greenend.org.uk/~sgtatham/putty/changes.html
 client: yes
 server: no

--- a/_impls/ssh-net.md
+++ b/_impls/ssh-net.md
@@ -6,8 +6,8 @@ license: "[MIT license](https://github.com/sshnet/SSH.NET/blob/develop/LICENSE)"
 first-release:
     date: 2010-09-16
 latest-release:
-    version: 2024.1.0
-    date: 2024-06-28
+    version: 2024.2.0
+    date: 2024-11-11
 changelog: https://github.com/sshnet/SSH.NET/releases
 client: yes
 server: no
@@ -20,23 +20,32 @@ protocols:
         - aes128-cbc
         - aes192-cbc
         - aes256-cbc
-        - blowfish-cbc
-        - twofish-cbc
-        - twofish192-cbc
-        - twofish128-cbc
-        - twofish256-cbc
-        - arcfour
-        - arcfour128
-        - arcfour256
-        - cast128-cbc
+        #- blowfish-cbc                 # removed in 2024.2.0
+        #- twofish-cbc                  # removed in 2024.2.0
+        #- twofish192-cbc               # removed in 2024.2.0
+        #- twofish128-cbc               # removed in 2024.2.0
+        #- twofish256-cbc               # removed in 2024.2.0
+        #- arcfour                      # removed in 2024.2.0
+        #- arcfour128                   # removed in 2024.2.0
+        #- arcfour256                   # removed in 2024.2.0
+        #- cast128-cbc                  # removed in 2024.2.0
         - aes128-ctr
         - aes192-ctr
         - aes128-gcm@openssh.com
         - aes256-gcm@openssh.com
+        - chacha20-poly1305@openssh.com # since 2024.2.0
     compression:
         - none
         - zlib@openssh.com
     hostkey:
+        - ssh-ed25519-cert-v01@openssh.com         # since 2024.2.0
+        - ecdsa-sha2-nistp256-cert-v01@openssh.com # since 2024.2.0
+        - ecdsa-sha2-nistp384-cert-v01@openssh.com # since 2024.2.0
+        - ecdsa-sha2-nistp521-cert-v01@openssh.com # since 2024.2.0
+        - rsa-sha2-512-cert-v01@openssh.com        # since 2024.2.0
+        - rsa-sha2-256-cert-v01@openssh.com        # since 2024.2.0
+        - ssh-rsa-cert-v01@openssh.com             # since 2024.2.0
+        - ssh-dss-cert-v01@openssh.com             # since 2024.2.0
         - ssh-ed25519
         - ecdsa-sha2-nistp256
         - ecdsa-sha2-nistp384
@@ -60,22 +69,22 @@ protocols:
         - kex-strict-c-v00@openssh.com
         - kex-strict-s-v00@openssh.com
     mac:
-        - hmac-md5
-        - hmac-md5-96
+        #- hmac-md5                      # removed in 2024.2.0
+        #- hmac-md5-96                   # removed in 2024.2.0
         - hmac-sha1
-        - hmac-sha1-96
+        #- hmac-sha1-96                  # removed in 2024.2.0
         - hmac-sha2-256
-        - hmac-sha2-256-96
+        #- hmac-sha2-256-96              # removed in 2024.2.0
         - hmac-sha2-512
-        - hmac-sha2-512-96
+        #- hmac-sha2-512-96              # removed in 2024.2.0
         #- hmac-ripemd160                # removed in 2024.0.0
         #- hmac-ripemd160@openssh.com    # removed in 2024.0.0
         - hmac-sha2-256-etm@openssh.com
         - hmac-sha2-512-etm@openssh.com
         - hmac-sha1-etm@openssh.com
-        - hmac-sha1-96-etm@openssh.com
-        - hmac-md5-etm@openssh.com
-        - hmac-md5-96-etm@openssh.com
+        #- hmac-sha1-96-etm@openssh.com  # removed in 2024.2.0
+        #- hmac-md5-etm@openssh.com      # removed in 2024.2.0
+        #- hmac-md5-96-etm@openssh.com   # removed in 2024.2.0
     userauth:
         - publickey
         - password

--- a/_impls/swift-nio-ssh.md
+++ b/_impls/swift-nio-ssh.md
@@ -6,8 +6,8 @@ license: "[Apache-2.0](https://github.com/apple/swift-nio-ssh/blob/main/LICENSE.
 first-release:
     date: 2020-04-14
 latest-release:
-    version: 0.9.0
-    date: 2024-03-26
+    version: 0.9.1
+    date: 2024-10-07
 changelog: https://github.com/apple/swift-nio-ssh/releases
 client: yes
 server: yes

--- a/_impls/twisted.md
+++ b/_impls/twisted.md
@@ -6,8 +6,8 @@ license: "[MIT](https://github.com/twisted/twisted/blob/trunk/LICENSE)"
 first-release:
     date: 2002-07-07    # Conch renamed from twisted.secsh
 latest-release:
-    version: 2024.7.0
-    date: 2024-08-08
+    version: 2024.11.0
+    date: 2024-12-02
 changelog: https://github.com/twisted/twisted/blob/trunk/NEWS.rst
 client: yes
 server: yes
@@ -21,10 +21,10 @@ protocols:
     cipher:
         - 3des-cbc
         - 3des-ctr
-        - blowfish-cbc
-        - blowfish-ctr
-        - cast128-cbc
-        - cast128-ctr
+        #- blowfish-cbc                 # removed in 2024.10.0
+        #- blowfish-ctr                 # removed in 2024.10.0
+        #- cast128-cbc                  # removed in 2024.10.0
+        #- cast128-ctr                  # removed in 2024.10.0
         - aes128-cbc
         - aes192-ctr
         - aes256-cbc
@@ -45,6 +45,8 @@ protocols:
         - ssh-ed25519                    # since 21.2.0
         - rsa-sha2-256                   # since 22.4.0
         - rsa-sha2-512                   # since 22.4.0
+        - sk-ecdsa-sha2-nistp256@openssh.com # since 24.10.0
+        - sk-ssh-ed25519@openssh.com     # since 24.10.0
 
     # See: https://github.com/twisted/twisted/blob/2a33824557ed65d2241a51d6bba07ac76521b50f/src/twisted/conch/ssh/_kex.py#L178
     kex:

--- a/_impls/wolfssh.md
+++ b/_impls/wolfssh.md
@@ -6,8 +6,8 @@ license: "Dual license: [GPLv3](https://github.com/wolfSSL/wolfssh/blob/master/L
 first-release:
     date: 2016-10-24
 latest-release:
-    version: 1.4.18
-    date: 2024-07-22
+    version: 1.4.19
+    date: 2024-11-01
 changelog: https://github.com/wolfSSL/wolfssh/blob/master/ChangeLog.md
 client: yes
 server: yes
@@ -41,6 +41,7 @@ protocols:
     kex:
         - diffie-hellman-group1-sha1
         - diffie-hellman-group14-sha1
+        - diffie-hellman-group14-sha256
         - diffie-hellman-group-exchange-sha256
         - ecdh-sha2-nistp256
         - ecdh-sha2-nistp384


### PR DESCRIPTION
- Update AsyncSSH to 2.19.0
- Update JSch to 0.2.22
- Update Erlang ssh library to 5.2.5
- Update phpseclib to 3.0.43
- Update Apache SSHD to 2.14.0
- Update Twisted Conch to 2024.11.0
- Update wolfSSH to 1.4.19
- Update SSH.NET to 2024.2.0
- Update Dropbear to 2024.86
- Update PuTTY to 0.82
- Update Net::SSH to 7.3.0
- Update SwiftNIO SSH to 0.9.1
- Update libssh2 to 1.11.1
- Update to latest IETF draft specs
- Update JSch to 0.2.23