### PR TITLE
Update to latest versions

### DIFF
--- a/_data/specs.yml
+++ b/_data/specs.yml
@@ -376,13 +376,23 @@ draft-ietf-secsh-filexfer-02:
     url: https://tools.ietf.org/html/draft-ietf-secsh-filexfer-02
     title: "SSH File Transfer Protocol [ expired 2002-04-01 ]"
 
-draft-ietf-sshm-chacha20-poly1305-00:
-    name: draft-ietf-sshm-chacha20-poly1305-00
-    url: https://tools.ietf.org/html/draft-ietf-sshm-chacha20-poly1305-00.html
-    title: "Secure Shell (SSH) authenticated encryption cipher: chacha20-poly1305 [ expired 2025-07-10 ]"
+draft-ietf-sshm-chacha20-poly1305-01:
+    name: draft-ietf-sshm-chacha20-poly1305-01
+    url: https://tools.ietf.org/html/draft-ietf-sshm-chacha20-poly1305-01.html
+    title: "Secure Shell (SSH) authenticated encryption cipher: chacha20-poly1305 [ expired 2025-09-18 ]"
     protocols:
         cipher:
             - chacha20-poly1305
+
+draft-ietf-sshm-mlkem-hybrid-kex-00:
+    name: draft-ietf-sshm-mlkem-hybrid-kex-00
+    url: https://tools.ietf.org/html/draft-ietf-sshm-mlkem-hybrid-kex-00.html
+    title: "PQ/T Hybrid Key Exchange in SSH [ expired 2025-08-02 ]"
+    protocols:
+        kex:
+            - mlkem768nistp256-sha256
+            - mlkem1024nistp384-sha384
+            - mlkem768x25519-sha256
 
 draft-ietf-sshm-ntruprime-ssh-01:
     name: draft-ietf-sshm-ntruprime-ssh-01
@@ -391,6 +401,30 @@ draft-ietf-sshm-ntruprime-ssh-01:
     protocols:
         kex:
             - sntrup761x25519-sha512
+
+draft-josefsson-ssh-frodokem-00:
+    name: draft-josefsson-ssh-frodokem-00
+    url: https://tools.ietf.org/html/draft-josefsson-ssh-frodokem-00.html
+    title: "Secure Shell Key Exchange Method Using Chempat Hybrid of FrodoKEM-976 and X25519 with SHA-512: frodokem976x25519-sha512 [ expired 2025-09-19 ]"
+    protocols:
+        kex:
+            - frodokem976x25519-sha512
+
+draft-josefsson-ssh-mceliece-01:
+    name: draft-josefsson-ssh-mceliece-01
+    url: https://tools.ietf.org/html/draft-josefsson-ssh-mceliece-01.html
+    title: "Secure Shell Key Exchange Method Using Chempat Hybrid of Classic McEliece and X25519 with SHA-512: mceliece6688128x25519-sha512 [ expired 2025-09-19 ]"
+    protocols:
+        kex:
+            - mceliece6688128x25519-sha512
+
+draft-josefsson-ssh-sphincs-00:
+    name: draft-josefsson-ssh-sphincs-00
+    url: https://tools.ietf.org/html/draft-josefsson-ssh-sphincs-00.html
+    title: "Stateless Hash-Based Signatures for the Secure Shell (SSH) Protocol [ expired 2025-08-08 ]"
+    protocols:
+        hostkey:
+            - ssh-slh-dsa-sha2-256f
 
 draft-kampanakis-curdle-ssh-pq-ke-01:
     name: draft-kampanakis-curdle-ssh-pq-ke-01
@@ -402,16 +436,6 @@ draft-kampanakis-curdle-ssh-pq-ke-01:
             - ecdh-nistp384-kyber-768r3-sha384-d00@openquantumsafe.org
             - ecdh-nistp521-kyber-1024r3-sha512-d00@openquantumsafe.org
             - x25519-kyber-512r3-sha256-d00@amazon.com
-
-draft-kampanakis-curdle-ssh-pq-ke-05:
-    name: draft-kampanakis-curdle-ssh-pq-ke-05
-    url: https://tools.ietf.org/html/draft-kampanakis-curdle-ssh-pq-ke-05.html
-    title: "PQ/T Hybrid Key Exchange in SSH [ expired 2025-06-08 ]"
-    protocols:
-        kex:
-            - mlkem768nistp256-sha256
-            - mlkem1024nistp384-sha384
-            - mlkem768x25519-sha256
 
 draft-kanno-secsh-camellia-02:
     name: draft-kanno-secsh-camellia-02
@@ -430,6 +454,24 @@ draft-kanno-secsh-camellia-02:
         mac:
             - AEAD_CAMELLIA_128_GCM
             - AEAD_CAMELLIA_256_GCM
+
+draft-miller-sshm-aes-gcm-00:
+    name: draft-miller-sshm-aes-gcm-00
+    url: https://tools.ietf.org/html/draft-miller-sshm-aes-gcm-00.html
+    title: "Fixed AES-GCM modes for the SSH protocol [ expired 2025-09-19 ]"
+    protocols:
+        cipher:
+            - aes128-gcm
+            - aes256-gcm
+
+draft-miller-sshm-strict-kex-01:
+    name: draft-miller-sshm-strict-kex-01
+    url: https://tools.ietf.org/html/draft-miller-sshm-strict-kex-01.html
+    title: "SSH Strict KEX extension [ expired 2025-09-19 ]"
+    protocols:
+        kex:
+            - kex-strict-c
+            - kex-strict-s
 
 draft-ssh-ext-auth-info-01:
     name: draft-ssh-ext-auth-info-01

--- a/_impls/apache-sshd.md
+++ b/_impls/apache-sshd.md
@@ -6,8 +6,8 @@ license: "[Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0)"
 first-release:
     date: 2009      # according to Wikipedia
 latest-release:
-    version: 2.14.0
-    date: 2024-10-04
+    version: 2.15.0
+    date: 2025-02-25
 changelog: "https://github.com/apache/mina-sshd/blob/master/CHANGES.md"
 client: yes
 server: yes
@@ -66,6 +66,9 @@ protocols:
         - curve25519-sha256
         - curve25519-sha256@libssh.org
         - curve448-sha512
+        - mlkem768x25519-sha256
+        - mlkem768nistp256-sha256
+        - mlkem1024nistp384-sha384
         - sntrup761x25519-sha512
         - sntrup761x25519-sha512@openssh.com
     mac:

--- a/_impls/asyncssh.md
+++ b/_impls/asyncssh.md
@@ -6,8 +6,8 @@ license: "[EPL v2.0](https://www.eclipse.org/legal/epl-2.0/faq.php)"
 first-release:
     date: 2013-09-14
 latest-release:
-    version: 2.19.0
-    date: 2024-12-12
+    version: 2.20.0
+    date: 2025-02-17
 changelog: https://asyncssh.readthedocs.io/en/latest/changes.html
 client: yes
 server: yes

--- a/_impls/cyclonessh.md
+++ b/_impls/cyclonessh.md
@@ -6,8 +6,8 @@ license: "Dual license: [GPLv2](http://www.gnu.org/licenses/old-licenses/gpl-2.0
 first-release:
     date: 2019-07-19
 latest-release:
-    version: 2.4.4
-    date: 2024-09-02
+    version: 2.5.0
+    date: 2025-02-10
 changelog: https://www.oryx-embedded.com/download.html#changelog
 client: yes
 server: yes

--- a/_impls/dropbear.md
+++ b/_impls/dropbear.md
@@ -6,8 +6,8 @@ license: "[MIT style](https://github.com/mkj/dropbear/blob/master/LICENSE)"
 first-release:
     date: 2003-04-06    # according to CHANGES file
 latest-release:
-    version: 2024.86
-    date: 2024-10-22
+    version: 2025.87
+    date: 2025-03-05
 changelog: https://matt.ucc.asn.au/dropbear/CHANGES
 client: yes
 server: yes
@@ -35,7 +35,7 @@ protocols:
         - ecdsa-sha2-nistp256
         - ecdsa-sha2-nistp384
         - ecdsa-sha2-nistp521
-        - ssh-rsa
+        # - ssh-rsa                      # disabled by default since 2025.87
         - rsa-sha2-256                   # since 2022.82
         # - ssh-dss                      # disabled by default since 2022.83
         - ssh-ed25519                    # since 2020.79
@@ -47,8 +47,11 @@ protocols:
         - ecdh-sha2-nistp521
         - ecdh-sha2-nistp384
         - ecdh-sha2-nistp256
-        - diffie-hellman-group14-sha1
+        # - diffie-hellman-group14-sha1  # disabled by default since 2025.87
         - diffie-hellman-group14-sha256   # since 2018.76
+        - mlkem768x25519-sha256              # since 2025.87
+        - sntrup761x25519-sha512             # since 2025.87
+        - sntrup761x25519-sha512@openssh.com # since 2025.87
         # - diffie-hellman-group16-sha512   # since 2018.76. disabled by default
         # - diffie-hellman-group1-sha1    # disabled by default
         - kexguess2@matt.ucc.asn.au     # Dropbear extension (only documented in their CHANGES file?)
@@ -57,7 +60,7 @@ protocols:
         - kex-strict-s-v00@openssh.com
     mac:
         # - hmac-sha1-96   # disabled by default
-        - hmac-sha1
+        # - hmac-sha1      # disabled by default since 2025.87
         - hmac-sha2-256
         # - hmac-sha2-512  # disabled by default
     userauth:

--- a/_impls/erlang.md
+++ b/_impls/erlang.md
@@ -6,8 +6,8 @@ license: "[Apache-2.0](https://github.com/erlang/otp/blob/maint/LICENSE.txt)"
 first-release:
     date: 2005-10-25
 latest-release:
-    version: 5.2.5 (OTP 27.2)
-    date: 2024-12-11
+    version: 5.2.8 (OTP 27.3)
+    date: 2025-03-05
 changelog: https://www.erlang.org/doc/apps/ssh/notes.html
 client: yes
 server: yes

--- a/_impls/jsch.md
+++ b/_impls/jsch.md
@@ -6,8 +6,8 @@ license: "[BSD style](https://github.com/mwiede/jsch/blob/master/LICENSE.txt)"
 #first-release:
 #    date: YYYY-MM-DD
 latest-release:
-    version: 0.2.23
-    date: 2025-01-26
+    version: 0.2.24
+    date: 2025-03-10
 changelog: https://github.com/mwiede/jsch/blob/master/ChangeLog.md
 client: yes
 server: no

--- a/_impls/paramiko.md
+++ b/_impls/paramiko.md
@@ -6,8 +6,8 @@ license: "[LGPL 2.1](https://github.com/paramiko/paramiko/blob/master/LICENSE)"
 first-release:
     date: 2003-09-13    # v0.1, according to NEWS file
 latest-release:
-    version: 3.5.0
-    date: 2024-09-15
+    version: 3.5.1
+    date: 2025-02-03
 changelog: https://www.paramiko.org/changelog.html
 client: yes
 server: yes

--- a/_impls/putty.md
+++ b/_impls/putty.md
@@ -15,8 +15,8 @@ first-release:
 # the development code made its first successful SSH connection 1998-05-29.
 # So, all in all, this is why I give 1998 as date of the first release.
 latest-release:
-    version: 0.82
-    date: 2024-11-27
+    version: 0.83
+    date: 2025-02-08
 changelog: https://www.chiark.greenend.org.uk/~sgtatham/putty/changes.html
 client: yes
 server: no
@@ -81,6 +81,10 @@ protocols:
         - ecdh-sha2-nistp256
         - ecdh-sha2-nistp384
         - ecdh-sha2-nistp521
+        - mlkem768x25519-sha256
+        - mlkem768nistp256-sha256
+        - mlkem1024nistp384-sha384
+        - sntrup761x25519-sha512
         - sntrup761x25519-sha512@openssh.com
         - rsa1024-sha1
         - rsa2048-sha256

--- a/_impls/tinyssh.md
+++ b/_impls/tinyssh.md
@@ -8,8 +8,8 @@ first-release:
     # see also https://news.ycombinator.com/item?id=7727738 from May 11, 2014
     # and http://tuxdiary.com/2014/05/11/tinyssh/
 latest-release:
-    version: 20240101
-    date: 2024-01-01
+    version: 20250201
+    date: 2025-02-01
 changelog: https://github.com/janmojzis/tinyssh/releases
 client: no
 server: yes

--- a/_impls/ttssh2.md
+++ b/_impls/ttssh2.md
@@ -6,8 +6,8 @@ license: "[BSD style](https://teratermproject.github.io/manual/5/en/about/copyri
 first-release:
     date: 2004    # according to Wikipedia
 latest-release:
-    version: 5.3
-    date: 2024-09-08
+    version: 5.4.0
+    date: 2025-03-03
 changelog: https://teratermproject.github.io/manual/5/en/about/history.html
 client: yes
 server: no

--- a/_impls/wolfssh.md
+++ b/_impls/wolfssh.md
@@ -6,8 +6,8 @@ license: "Dual license: [GPLv3](https://github.com/wolfSSL/wolfssh/blob/master/L
 first-release:
     date: 2016-10-24
 latest-release:
-    version: 1.4.19
-    date: 2024-11-01
+    version: 1.4.20
+    date: 2025-02-20
 changelog: https://github.com/wolfSSL/wolfssh/blob/master/ChangeLog.md
 client: yes
 server: yes
@@ -42,6 +42,7 @@ protocols:
         - diffie-hellman-group1-sha1
         - diffie-hellman-group14-sha1
         - diffie-hellman-group14-sha256
+        - diffie-hellman-group16-sha512
         - diffie-hellman-group-exchange-sha256
         - ecdh-sha2-nistp256
         - ecdh-sha2-nistp384
@@ -53,7 +54,9 @@ protocols:
         - hmac-sha1
         - hmac-sha1-96
         - hmac-sha2-256
+        - hmac-sha2-512
     userauth:
+        - keyboard-interactive
         - password
         - publickey
     extension:


### PR DESCRIPTION
- Update to latest IETF draft specs
- Update JSch to 0.2.24
- Update AsyncSSH to 2.20.0
- Update Erlang ssh library to 5.2.8
- Update PuTTY to 0.83
- Update wolfSSH to 1.4.20
- Update Dropbear to 2025.87
- Update Apache SSHD to 2.15.0
- Update Paramiko to 3.5.1
- Update Tera Term to 5.4.0
- Update CycloneSSH to 2.5.0
- Update TinySSH to 20250201