### PR TITLE
Update to latest versions

### DIFF
--- a/_data/specs.yml
+++ b/_data/specs.yml
@@ -414,10 +414,10 @@ draft-ietf-sshm-mlkem-hybrid-kex-02:
             - mlkem1024nistp384-sha384
             - mlkem768x25519-sha256
 
-draft-ietf-sshm-ntruprime-ssh-02:
-    name: draft-ietf-sshm-ntruprime-ssh-02
-    url: https://datatracker.ietf.org/doc/html/draft-ietf-sshm-ntruprime-ssh-02.html
-    title: "Secure Shell (SSH) Key Exchange Method Using Hybrid Streamlined NTRU Prime sntrup761 and X25519 with SHA-512: sntrup761x25519-sha512 [ expired 2025-10-26 ]"
+draft-ietf-sshm-ntruprime-ssh-03:
+    name: draft-ietf-sshm-ntruprime-ssh-03
+    url: https://datatracker.ietf.org/doc/html/draft-ietf-sshm-ntruprime-ssh-03.html
+    title: "Secure Shell (SSH) Key Exchange Method Using Hybrid Streamlined NTRU Prime sntrup761 and X25519 with SHA-512: sntrup761x25519-sha512 [ expired 2025-11-17 ]"
     protocols:
         kex:
             - sntrup761x25519-sha512

--- a/_impls/asyncssh.md
+++ b/_impls/asyncssh.md
@@ -6,8 +6,8 @@ license: "[EPL v2.0](https://www.eclipse.org/legal/epl-2.0/faq.php)"
 first-release:
     date: 2013-09-14
 latest-release:
-    version: 2.20.0
-    date: 2025-02-17
+    version: 2.21.0
+    date: 2025-05-02
 changelog: https://asyncssh.readthedocs.io/en/latest/changes.html
 client: yes
 server: yes

--- a/_impls/dropbear.md
+++ b/_impls/dropbear.md
@@ -6,8 +6,8 @@ license: "[MIT style](https://github.com/mkj/dropbear/blob/master/LICENSE)"
 first-release:
     date: 2003-04-06    # according to CHANGES file
 latest-release:
-    version: 2025.87
-    date: 2025-03-05
+    version: 2025.88
+    date: 2025-05-07
 changelog: https://matt.ucc.asn.au/dropbear/CHANGES
 client: yes
 server: yes

--- a/_impls/erlang.md
+++ b/_impls/erlang.md
@@ -6,8 +6,8 @@ license: "[Apache-2.0](https://github.com/erlang/otp/blob/maint/LICENSE.txt)"
 first-release:
     date: 2005-10-25
 latest-release:
-    version: 5.2.10 (OTP 27.3.3)
-    date: 2025-04-16
+    version: 5.2.11 (OTP 27.3.4)
+    date: 2025-05-08
 changelog: https://www.erlang.org/doc/apps/ssh/notes.html
 client: yes
 server: yes

--- a/_impls/jsch.md
+++ b/_impls/jsch.md
@@ -6,8 +6,8 @@ license: "[BSD style](https://github.com/mwiede/jsch/blob/master/LICENSE.txt)"
 #first-release:
 #    date: YYYY-MM-DD
 latest-release:
-    version: 0.2.26
-    date: 2025-04-28
+    version: 2.27.0
+    date: 2025-05-08
 changelog: https://github.com/mwiede/jsch/blob/master/ChangeLog.md
 client: yes
 server: no

--- a/_impls/poderosa.md
+++ b/_impls/poderosa.md
@@ -7,8 +7,8 @@ license: "[Apache-2.0](https://github.com/poderosaproject/poderosa/blob/master/L
 #    date: YYYY-MM-DD
 #   version 3.0.0 on SourceForge.net ist dated 2005-04-28
 latest-release:
-    version: 4.7.0
-    date: 2024-08-20
+    version: 4.8.0
+    date: 2025-05-08
 changelog: https://github.com/poderosaproject/poderosa/blob/master/ChangeLog.txt
 client: yes
 server: no

--- a/_impls/tinyssh.md
+++ b/_impls/tinyssh.md
@@ -8,8 +8,8 @@ first-release:
     # see also https://news.ycombinator.com/item?id=7727738 from May 11, 2014
     # and http://tuxdiary.com/2014/05/11/tinyssh/
 latest-release:
-    version: 20250201
-    date: 2025-02-01
+    version: 20250501
+    date: 2025-05-01
 changelog: https://github.com/janmojzis/tinyssh/releases
 client: no
 server: yes


### PR DESCRIPTION
- Update JSch to 2.27.0
- Update Erlang ssh library to 5.2.11
- Update Dropbear to 2025.88
- Update AsyncSSH to 2.21.0
- Update TinySSH to 20250501
- Update Poderosa to 4.8.0
- Update to latest IETF draft specs