### PR TITLE
Update to latest versions

### DIFF
--- a/_impls/go-cryptography.md
+++ b/_impls/go-cryptography.md
@@ -6,8 +6,8 @@ license: "[BSD style](https://cs.opensource.google/go/x/crypto/+/master:LICENSE)
 first-release:
     date: 2022-10-19
 latest-release:
-    version: 0.40.0
-    date: 2025-07-10
+    version: 0.41.0
+    date: 2025-08-07
 #changelog: ?
 client: yes
 server: yes

--- a/_impls/moussh.md
+++ b/_impls/moussh.md
@@ -7,7 +7,8 @@ license: "[Public Domain](http://ftp.rodents-montreal.org/mouse/git-unpacked/mou
 #    date: YYYY-MM-DD
 latest-release:
     version: 0.9.2fe6d57aff
-    date: 2023-11-02
+    version: 0.9.20250724104234w0400.e4f5ecd6ab
+    date: 2025-07-24
 #changelog: TODO
 client: yes
 server: yes

--- a/_impls/paramiko.md
+++ b/_impls/paramiko.md
@@ -6,8 +6,8 @@ license: "[LGPL 2.1](https://github.com/paramiko/paramiko/blob/master/LICENSE)"
 first-release:
     date: 2003-09-13    # v0.1, according to NEWS file
 latest-release:
-    version: 3.5.1
-    date: 2025-02-03
+    version: 4.0.0
+    date: 2025-08-03
 changelog: https://www.paramiko.org/changelog.html
 client: yes
 server: yes
@@ -33,7 +33,7 @@ protocols:
         - none
     hostkey:
         - ssh-rsa
-        - ssh-dss
+        #- ssh-dss              # removed in 4.0.0
         - ecdsa-sha2-nistp256   # since 1.12.0 (2013-09-27)
         - ecdsa-sha2-nistp384   # since 2.0.0 (2016-04-28)
         - ecdsa-sha2-nistp521   # since 2.0.0 (2016-04-28)
@@ -41,7 +41,7 @@ protocols:
         - rsa-sha2-512
         - ssh-ed25519
         - ssh-rsa-cert-v01@openssh.com
-        - ssh-dss-cert-v01@openssh.com
+        #- ssh-dss-cert-v01@openssh.com #removed in 4.0.0
         - ecdsa-sha2-nistp256-cert-v01@openssh.com
         - ecdsa-sha2-nistp384-cert-v01@openssh.com
         - ecdsa-sha2-nistp521-cert-v01@openssh.com

--- a/_impls/ttssh2.md
+++ b/_impls/ttssh2.md
@@ -6,8 +6,8 @@ license: "[BSD style](https://teratermproject.github.io/manual/5/en/about/copyri
 first-release:
     date: 2004    # according to Wikipedia
 latest-release:
-    version: 5.4.0
-    date: 2025-03-03
+    version: 5.4.1
+    date: 2025-08-03
 changelog: https://teratermproject.github.io/manual/5/en/about/history.html
 client: yes
 server: no


### PR DESCRIPTION
- Update Go Cryptography to 0.41.0
- Update Tera Term to 5.4.1
- Update Paramiko to 4.0.0
- Update moussh to 0.9.20250724104234w0400.e4f5ecd6ab