### PR TITLE
Update to latest versions

### DIFF
--- a/_impls/go-cryptography.md
+++ b/_impls/go-cryptography.md
@@ -6,8 +6,8 @@ license: "[BSD style](https://cs.opensource.google/go/x/crypto/+/master:LICENSE)
 first-release:
     date: 2022-10-19
 latest-release:
-    version: 0.41.0
-    date: 2025-08-07
+    version: 0.42.0
+    date: 2025-09-08
 #changelog: ?
 client: yes
 server: yes

--- a/_impls/libssh.md
+++ b/_impls/libssh.md
@@ -10,8 +10,8 @@ first-release:
 # Looking at the initial commit in the git repository, it contains
 # a CHANGELOG which contains the date of the initial release.
 latest-release:
-    version: 0.11.2
-    date: 2025-06-24
+    version: 0.11.3
+    date: 2025-09-09
 changelog: https://git.libssh.org/projects/libssh.git/tree/CHANGELOG?h=stable-0.11
 client: yes
 server: yes


### PR DESCRIPTION
- Update Go Cryptography to 0.42.0
- Update libssh to 0.11.3