### PR TITLE
Update to latest versions

### DIFF
--- a/_data/specs.yml
+++ b/_data/specs.yml
@@ -410,10 +410,10 @@ draft-ietf-sshm-mlkem-hybrid-kex-03:
             - mlkem1024nistp384-sha384
             - mlkem768x25519-sha256
 
-draft-ietf-sshm-ntruprime-ssh-05:
-    name: draft-ietf-sshm-ntruprime-ssh-05
-    url: https://datatracker.ietf.org/doc/html/draft-ietf-sshm-ntruprime-ssh-05.html
-    title: "Secure Shell (SSH) Key Exchange Method Using Hybrid Streamlined NTRU Prime sntrup761 and X25519 with SHA-512: sntrup761x25519-sha512 [ expired 2026-02-16 ]"
+draft-ietf-sshm-ntruprime-ssh-06:
+    name: draft-ietf-sshm-ntruprime-ssh-06
+    url: https://datatracker.ietf.org/doc/html/draft-ietf-sshm-ntruprime-ssh-06.html
+    title: "Secure Shell (SSH) Key Exchange Method Using Hybrid Streamlined NTRU Prime sntrup761 and X25519 with SHA-512: sntrup761x25519-sha512 [ expired 2026-04-03 ]"
     protocols:
         kex:
             - sntrup761x25519-sha512

--- a/_impls/cyclonessh.md
+++ b/_impls/cyclonessh.md
@@ -6,8 +6,8 @@ license: "Dual license: [GPLv2](http://www.gnu.org/licenses/old-licenses/gpl-2.0
 first-release:
     date: 2019-07-19
 latest-release:
-    version: 2.5.2
-    date: 2025-06-06
+    version: 2.5.4
+    date: 2025-09-26
 changelog: https://www.oryx-embedded.com/download.html#changelog
 client: yes
 server: yes

--- a/_impls/hpn-ssh.md
+++ b/_impls/hpn-ssh.md
@@ -6,8 +6,8 @@ license: "[BSD](https://github.com/rapier1/hpn-ssh/blob/master/LICENCE)"
 first-release:
     date: 2004
 latest-release:
-    version: 18.7.0
-    date: 2025-04-10
+    version: 18.7.1
+    date: 2025-09-30
 changelog: https://github.com/rapier1/hpn-ssh/releases
 client: yes
 server: yes


### PR DESCRIPTION
- Update to latest IETF draft specs
- Update CycloneSSH to 2.5.4
- Update HPN-SSH to 18.7.1