### PR TITLE
Add curve25519-sha256@libssh.org to key exchange methods

### DIFF
--- a/_impls/absolutetelnet.md
+++ b/_impls/absolutetelnet.md
@@ -49,6 +49,7 @@ protocols:
         - mlkem768x25519-sha256
         - sntrup761x25519-sha512
         - curve25519-sha256
+        - curve25519-sha256@libssh.org
         - ecdh-sha2-nistp521
         - ecdh-sha2-nistp384
         - ecdh-sha2-nistp256


### PR DESCRIPTION
Working through the lists...  Found this one was missing.  This is the vendor specific name 'curve25519-sha256@libssh.org'