### PR TITLE
Update to latest versions

### DIFF
--- a/_data/specs.yml
+++ b/_data/specs.yml
@@ -480,17 +480,6 @@ draft-josefsson-sshsig-format-03:
     url: https://tools.ietf.org/html/draft-josefsson-sshsig-format-03.html
     title: "Lightweight Secure Shell (SSH) Signature Format [ expired 2026-01-08 ]"
 
-draft-kampanakis-curdle-ssh-pq-ke-01:
-    name: draft-kampanakis-curdle-ssh-pq-ke-01
-    url: https://tools.ietf.org/html/draft-kampanakis-curdle-ssh-pq-ke-01.html
-    title: "Post-quantum Hybrid Key Exchange in SSH [ expired 2023-10-12 ]"
-    protocols:
-        kex:
-            - ecdh-nistp256-kyber-512r3-sha256-d00@openquantumsafe.org
-            - ecdh-nistp384-kyber-768r3-sha384-d00@openquantumsafe.org
-            - ecdh-nistp521-kyber-1024r3-sha512-d00@openquantumsafe.org
-            - x25519-kyber-512r3-sha256-d00@amazon.com
-
 draft-kanno-secsh-camellia-02:
     name: draft-kanno-secsh-camellia-02
     url: https://tools.ietf.org/html/draft-kanno-secsh-camellia-02

--- a/_impls/hpn-ssh.md
+++ b/_impls/hpn-ssh.md
@@ -6,8 +6,8 @@ license: "[BSD](https://github.com/rapier1/hpn-ssh/blob/master/LICENCE)"
 first-release:
     date: 2004
 latest-release:
-    version: 18.7.1
-    date: 2025-09-30
+    version: 18.8.0
+    date: 2025-10-23
 changelog: https://github.com/rapier1/hpn-ssh/releases
 client: yes
 server: yes

--- a/_impls/wolfssh.md
+++ b/_impls/wolfssh.md
@@ -6,8 +6,8 @@ license: "Dual license: [GPLv3](https://github.com/wolfSSL/wolfssh/blob/master/L
 first-release:
     date: 2016-10-24
 latest-release:
-    version: 1.4.20
-    date: 2025-02-20
+    version: 1.4.21
+    date: 2025-10-20
 changelog: https://github.com/wolfSSL/wolfssh/blob/master/ChangeLog.md
 client: yes
 server: yes
@@ -48,7 +48,8 @@ protocols:
         - ecdh-sha2-nistp384
         - ecdh-sha2-nistp521
         - curve25519-sha256
-        - ecdh-nistp256-kyber-512r3-sha256-d00@openquantumsafe.org
+        - curve25519-sha256@libssh.org
+        - mlkem768nistp256-sha256
         - ext-info-c
     mac:
         - hmac-sha1


### PR DESCRIPTION
- Update HPN-SSH to 18.8.0
- Update wolfSSH to 1.4.21
- Update to latest IETF draft specs