### PR TITLE
Update to latest versions

### DIFF
--- a/_data/specs.yml
+++ b/_data/specs.yml
@@ -432,10 +432,10 @@ draft-ietf-sshm-strict-kex-00:
             - kex-strict-c
             - kex-strict-s
 
-draft-josefsson-ssh-ed25519mldsa65-00:
-    name: draft-josefsson-ssh-ed25519mldsa65-00
-    url: https://tools.ietf.org/html/draft-josefsson-ssh-ed25519mldsa65-00.html
-    title: "Hybrid Ed25519 with ML-DSA-65 for Secure Shell (SSH) [ expired 2026-04-20 ]"
+draft-josefsson-ssh-ed25519mldsa65-01:
+    name: draft-josefsson-ssh-ed25519mldsa65-01
+    url: https://tools.ietf.org/html/draft-josefsson-ssh-ed25519mldsa65-01.html
+    title: "Hybrid Ed25519 with ML-DSA-65 for Secure Shell (SSH) [ expired 2026-04-22 ]"
     protocols:
         hostkey:
             - ssh-ed25519-ml-dsa-65

--- a/_impls/jsch.md
+++ b/_impls/jsch.md
@@ -6,8 +6,8 @@ license: "[BSD style](https://github.com/mwiede/jsch/blob/master/LICENSE.txt)"
 first-release:
     date: 2002-10-20
 latest-release:
-    version: 2.27.4
-    date: 2025-10-21
+    version: 2.27.5
+    date: 2025-10-27
 changelog: https://github.com/mwiede/jsch/releases
 client: yes
 server: no

--- a/_impls/ssh-net.md
+++ b/_impls/ssh-net.md
@@ -6,8 +6,8 @@ license: "[MIT license](https://github.com/sshnet/SSH.NET/blob/develop/LICENSE)"
 first-release:
     date: 2010-09-16
 latest-release:
-    version: 2025.0.0
-    date: 2025-04-18
+    version: 2025.1.0
+    date: 2025-10-27
 changelog: https://github.com/sshnet/SSH.NET/releases
 client: yes
 server: no
@@ -62,6 +62,7 @@ protocols:
         - ecdh-sha2-nistp521
         - diffie-hellman-group-exchange-sha256
         - diffie-hellman-group-exchange-sha1
+        - diffie-hellman-group18-sha512        # since 2025.1.0
         - diffie-hellman-group16-sha512
         - diffie-hellman-group14-sha256
         - diffie-hellman-group14-sha1


### PR DESCRIPTION
- Update JSch to 2.27.5
- Update SSH.NET to 2025.1.0
- Update to latest IETF draft specs