### PR TITLE
Update to latest versions

### DIFF
--- a/_data/specs.yml
+++ b/_data/specs.yml
@@ -386,10 +386,10 @@ draft-becker-cnsa2-ssh-profile-02:
     url: https://tools.ietf.org/html/draft-becker-cnsa2-ssh-profile-02.html
     title: "Commercial National Security Algorithm (CNSA) Suite Profile for SSH [ expired 2026-03-02 ]"
 
-draft-gutmann-ssh-preauth-04:
-    name: draft-gutmann-ssh-preauth-04
-    url: https://tools.ietf.org/html/draft-gutmann-ssh-preauth-04.html
-    title: "A Pre-Authentication Mechanism for SSH [ expired 2026-02-18 ]"
+draft-gutmann-ssh-preauth-05:
+    name: draft-gutmann-ssh-preauth-05
+    url: https://tools.ietf.org/html/draft-gutmann-ssh-preauth-05.html
+    title: "A Pre-Authentication Mechanism for SSH [ expired 2026-08-14 ]"
 
 draft-harrison-sshm-mlkem-01:
     name: draft-harrison-sshm-mlkem-01
@@ -422,10 +422,10 @@ draft-ietf-sshm-chacha20-poly1305-02:
         cipher:
             - chacha20-poly1305
 
-draft-ietf-sshm-mlkem-hybrid-kex-08:
-    name: draft-ietf-sshm-mlkem-hybrid-kex-08
-    url: https://tools.ietf.org/html/draft-ietf-sshm-mlkem-hybrid-kex-08.html
-    title: "PQ/T Hybrid Key Exchange with ML-KEM in SSH [ expired 2026-07-10 ]"
+draft-ietf-sshm-mlkem-hybrid-kex-09:
+    name: draft-ietf-sshm-mlkem-hybrid-kex-09
+    url: https://tools.ietf.org/html/draft-ietf-sshm-mlkem-hybrid-kex-09.html
+    title: "PQ/T Hybrid Key Exchange with ML-KEM in SSH [ expired 2026-08-06 ]"
     protocols:
         kex:
             - mlkem768nistp256-sha256
@@ -610,10 +610,10 @@ draft-sfluhrer-ssh-mldsa-02:
             - ssh-mldsa65
             - ssh-mldsa87
 
-draft-sfluhrer-ssh-mldsa-04:
-    name: draft-sfluhrer-ssh-mldsa-04
-    url: https://tools.ietf.org/html/draft-sfluhrer-ssh-mldsa-04.html
-    title: "SSH Support of ML-DSA [ expired 2026-02-12 ]"
+draft-sfluhrer-ssh-mldsa-05:
+    name: draft-sfluhrer-ssh-mldsa-05
+    url: https://tools.ietf.org/html/draft-sfluhrer-ssh-mldsa-05.html
+    title: "SSH Support of ML-DSA [ expired 2026-08-08 ]"
     protocols:
         hostkey:
             - ssh-mldsa-44

--- a/_impls/apache-sshd.md
+++ b/_impls/apache-sshd.md
@@ -6,8 +6,8 @@ license: "[Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0)"
 first-release:
     date: 2009      # according to Wikipedia
 latest-release:
-    version: 2.17.0
-    date: 2026-01-21
+    version: 2.17.1
+    date: 2026-01-27
 changelog: "https://github.com/apache/mina-sshd/blob/master/CHANGES.md"
 client: yes
 server: yes

--- a/_impls/go-cryptography.md
+++ b/_impls/go-cryptography.md
@@ -6,8 +6,8 @@ license: "[BSD style](https://cs.opensource.google/go/x/crypto/+/master:LICENSE)
 first-release:
     date: 2022-10-19
 latest-release:
-    version: 0.47.0
-    date: 2026-01-12
+    version: 0.48.0
+    date: 2026-02-09
 #changelog: ?
 client: yes
 server: yes

--- a/_impls/libssh.md
+++ b/_impls/libssh.md
@@ -10,9 +10,9 @@ first-release:
 # Looking at the initial commit in the git repository, it contains
 # a CHANGELOG which contains the date of the initial release.
 latest-release:
-    version: 0.11.3
-    date: 2025-09-09
-changelog: https://git.libssh.org/projects/libssh.git/tree/CHANGELOG?h=stable-0.11
+    version: 0.12.0
+    date: 2026-02-10
+changelog: https://git.libssh.org/projects/libssh.git/tree/CHANGELOG?h=libssh-0.12.0
 client: yes
 server: yes
 library: both
@@ -55,10 +55,10 @@ protocols:
         - ssh-rsa-cert-v01@openssh.com
         #- ssh-dss                                    # removed in 0.11.0
         #- ssh-dss-cert-v01@openssh.com               # removed in 0.11.0
-        - sk-ssh-ed25519@openssh.com                  # since 0.10.0, server side only
-        - sk-ssh-ed25519-cert-v01@openssh.com         # since 0.10.0, server side only
-        - sk-ecdsa-sha2-nistp256@openssh.com          # since 0.10.0, server side only
-        - sk-ecdsa-sha2-nistp256-cert-v01@openssh.com # since 0.10.0, server side only
+        - sk-ssh-ed25519@openssh.com                  # since 0.10.0, server side only; since 0.12.0, client side too
+        - sk-ssh-ed25519-cert-v01@openssh.com         # since 0.10.0, server side only; since 0.12.0, client side too
+        - sk-ecdsa-sha2-nistp256@openssh.com          # since 0.10.0, server side only; since 0.12.0, client side too
+        - sk-ecdsa-sha2-nistp256-cert-v01@openssh.com # since 0.10.0, server side only; since 0.12.0, client side too
     kex:
         - curve25519-sha256
         - curve25519-sha256@libssh.org
@@ -72,6 +72,15 @@ protocols:
         - diffie-hellman-group-exchange-sha1
         - diffie-hellman-group14-sha1
         - diffie-hellman-group1-sha1
+        - gss-curve25519-sha256-*
+        - gss-group14-sha256-*
+        - gss-group16-sha512-*
+        - gss-nistp256-sha256-*
+        - mlkem768nistp256-sha256
+        - mlkem768x25519-sha256
+        - mlkem1024nistp384-sha384
+        - sntrup761x25519-sha512
+        - sntrup761x25519-sha512@openssh.com
         - ext-info-c
         - kex-strict-c-v00@openssh.com
         - kex-strict-s-v00@openssh.com
@@ -88,7 +97,9 @@ protocols:
         - hostbased
         - keyboard-interactive
         - gssapi-with-mic
+        - publickey-hostbound-v00@openssh.com
     extension:
+        - publickey-hostbound@openssh.com
         - server-sig-algs
 ---
 * Mulitplatform C library for clients and servers.

--- a/_impls/phpseclib.md
+++ b/_impls/phpseclib.md
@@ -6,8 +6,8 @@ license: "[MIT style](https://github.com/phpseclib/phpseclib/blob/master/LICENSE
 first-release:
     date: 2007-09-23
 latest-release:
-    version: 3.0.48
-    date: 2025-12-15
+    version: 3.0.49
+    date: 2026-01-27
 changelog: https://github.com/phpseclib/phpseclib/blob/master/CHANGELOG.md
 client: yes
 server: no

--- a/_impls/russh.md
+++ b/_impls/russh.md
@@ -6,8 +6,8 @@ license: "[Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0)"
 first-release:
     date: 2022-03-13
 latest-release:
-    version: 0.56.0
-    date: 2025-12-22
+    version: 0.57.0
+    date: 2026-01-24
 changelog: https://github.com/Eugeny/russh/releases
 client: yes
 server: yes


### PR DESCRIPTION
- Update Apache SSHD to 2.17.1
- Update Go Cryptography to 0.48.0
- Update Russh to 0.57.0
- Update phpseclib to 3.0.49
- Update libssh to 0.12.0
- Update to latest IETF draft specs