### PR TITLE
Update to latest versions

### DIFF
--- a/_data/specs.yml
+++ b/_data/specs.yml
@@ -422,6 +422,14 @@ draft-ietf-sshm-chacha20-poly1305-02:
         cipher:
             - chacha20-poly1305
 
+draft-ietf-sshm-hostkey-update-00:
+    name: draft-ietf-sshm-hostkey-update-00
+    url: https://tools.ietf.org/html/draft-ietf-sshm-hostkey-update-00.html
+    title: "Host key update mechanism for SSH [ expired 2026-10-07 ]"
+    protocols:
+        extension:
+            - hostkeys
+
 draft-ietf-sshm-mlkem-hybrid-kex-10:
     name: draft-ietf-sshm-mlkem-hybrid-kex-10
     url: https://tools.ietf.org/html/draft-ietf-sshm-mlkem-hybrid-kex-10.html
@@ -575,14 +583,6 @@ draft-miller-sshm-aes-gcm-01:
             - aes128-gcm
             - aes256-gcm
 
-draft-miller-sshm-hostkey-update-02:
-    name: draft-miller-sshm-hostkey-update-02
-    url: https://tools.ietf.org/html/draft-miller-sshm-hostkey-update-02.html
-    title: "Host key update mechanism for SSH [ expired 2026-03-01 ]"
-    protocols:
-        extension:
-            - hostkeys
-
 draft-rpe-ssh-mldsa-02:
     name: draft-rpe-ssh-mldsa-02
     url: https://tools.ietf.org/html/draft-rpe-ssh-mldsa-02.html
@@ -603,10 +603,10 @@ draft-rpe-ssh-x509-mldsa-00:
             - x509v3-mldsa-65
             - x509v3-mldsa-87
 
-draft-sfluhrer-ssh-mldsa-05:
-    name: draft-sfluhrer-ssh-mldsa-05
-    url: https://tools.ietf.org/html/draft-sfluhrer-ssh-mldsa-05.html
-    title: "SSH Support of ML-DSA [ expired 2026-08-08 ]"
+draft-sfluhrer-ssh-mldsa-06:
+    name: draft-sfluhrer-ssh-mldsa-06
+    url: https://tools.ietf.org/html/draft-sfluhrer-ssh-mldsa-06.html
+    title: "SSH Support of ML-DSA [ expired 2026-10-09 ]"
     protocols:
         hostkey:
             - ssh-mldsa-44

--- a/_impls/go-cryptography.md
+++ b/_impls/go-cryptography.md
@@ -6,8 +6,8 @@ license: "[BSD style](https://cs.opensource.google/go/x/crypto/+/master:LICENSE)
 first-release:
     date: 2022-10-19
 latest-release:
-    version: 0.49.0
-    date: 2026-03-11
+    version: 0.50.0
+    date: 2026-04-09
 #changelog: ?
 client: yes
 server: yes

--- a/_impls/pkix-ssh.md
+++ b/_impls/pkix-ssh.md
@@ -6,8 +6,8 @@ license: "[BSD](https://gitlab.com/secsh/pkixssh/-/blob/master/LICENCE)"
 first-release:
     date: 2002-04-04
 latest-release:
-    version: 17.2.2
-    date: 2025-12-27
+    version: 18.0.2
+    date: 2026-04-05
 changelog: https://roumenpetrov.info/secsh/#news
 client: yes
 server: yes
@@ -56,19 +56,19 @@ protocols:
         - ssh-dss                           # disabled by default
     kex:
         - curve448-sha512
-        - diffie-hellman-group17-sha512
-        - diffie-hellman-group15-sha512
+        - diffie-hellman-group17-sha512     # disabled by default
+        - diffie-hellman-group15-sha512     # disabled by default
         - curve25519-sha256
         - curve25519-sha256@libssh.org
         - ecdh-sha2-nistp256
         - ecdh-sha2-nistp384
         - ecdh-sha2-nistp521
-        - diffie-hellman-group-exchange-sha256
-        - diffie-hellman-group-exchange-sha1
-        - diffie-hellman-group14-sha1
-        - diffie-hellman-group1-sha1
-        - diffie-hellman-group14-sha256
-        - diffie-hellman-group16-sha512
+        - diffie-hellman-group-exchange-sha256 # disabled by default
+        - diffie-hellman-group-exchange-sha1   # disabled by default
+        - diffie-hellman-group14-sha1       # disabled by default
+        - diffie-hellman-group1-sha1        # disabled by default
+        - diffie-hellman-group14-sha256     # disabled by default
+        - diffie-hellman-group16-sha512     # disabled by default
         - diffie-hellman-group18-sha512
         - ext-info-c
         - kex-strict-c-v00@openssh.com      # disabled by default

--- a/_impls/russh.md
+++ b/_impls/russh.md
@@ -6,8 +6,8 @@ license: "[Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0)"
 first-release:
     date: 2022-03-13
 latest-release:
-    version: 0.59.0
-    date: 2026-03-31
+    version: 0.60.0
+    date: 2026-04-03
 changelog: https://github.com/Eugeny/russh/releases
 client: yes
 server: yes


### PR DESCRIPTION
- Update to latest IETF draft specs
- Update Russh to 0.60.0
- Update Go Cryptography to 0.50.0
- Update PKIX-SSH to 18.0.2