### PR TITLE
Update to latest versions

### DIFF
--- a/_data/specs.yml
+++ b/_data/specs.yml
@@ -513,10 +513,10 @@ draft-josefsson-ssh-mceliece-02:
         kex:
             - mceliece6688128x25519-sha512
 
-draft-josefsson-ssh-sphincs-01:
-    name: draft-josefsson-ssh-sphincs-01
-    url: https://tools.ietf.org/html/draft-josefsson-ssh-sphincs-01.html
-    title: "Stateless Hash-Based Signatures for Secure Shell (SSH) [ expired 2026-04-23 ]"
+draft-josefsson-ssh-sphincs-02:
+    name: draft-josefsson-ssh-sphincs-02
+    url: https://tools.ietf.org/html/draft-josefsson-ssh-sphincs-02.html
+    title: "Stateless Hash-Based Signatures for Secure Shell (SSH) [ expired 2026-11-07 ]"
     protocols:
         hostkey:
             - ssh-slh-dsa-sha2-128s
@@ -527,10 +527,20 @@ draft-josefsson-ssh-sphincs-01:
             - ssh-slh-dsa-sha2-256f
             - ssh-slh-dsa-shake-256s
             - ssh-slh-dsa-shake-256f
+            - ssh-slh-dsa-sha2-128-24
+            - ssh-slh-dsa-shake-128-24
+            - ssh-slh-dsa-sha2-192-24
+            - ssh-slh-dsa-shake-192-24
+            - ssh-slh-dsa-sha2-256-24
+            - ssh-slh-dsa-shake-256-24
             - ssh-ed25519-slh-dsa-shake-128s
             - ssh-ed25519-slh-dsa-shake-128f
             - ssh-ed448-slh-dsa-shake-256s
             - ssh-ed448-slh-dsa-shake-256f
+            - ssh-ed25519-slh-dsa-sha2-128-24
+            - ssh-ed25519-slh-dsa-shake-128-24
+            - ssh-ed448-slh-dsa-sha2-256-24
+            - ssh-ed448-slh-dsa-shake-256-24
 
 draft-josefsson-sshsig-format-03:
     name: draft-josefsson-sshsig-format-03
@@ -592,6 +602,14 @@ draft-miller-sshm-aes-gcm-01:
         cipher:
             - aes128-gcm
             - aes256-gcm
+
+draft-miller-sshm-mldsa65-ed25519-composite-sigs-00:
+    name: draft-miller-sshm-mldsa65-ed25519-composite-sigs-00
+    url: https://tools.ietf.org/html/draft-miller-sshm-mldsa65-ed25519-composite-sigs-00.html
+    title: "ML-DSA 65/Ed255192 Composite Signatures in SSH [ expired 2026-10-30 ]"
+    protocols:
+        hostkey:
+            - ssh-mldsa65-ed25519@openssh.com
 
 draft-rpe-ssh-mldsa-03:
     name: draft-rpe-ssh-mldsa-03

--- a/_impls/connectbot.md
+++ b/_impls/connectbot.md
@@ -7,8 +7,8 @@ license: "[Apache-2.0](https://github.com/connectbot/connectbot/blob/main/LICENS
 first-release:
     date: 2007-11   # according to Wikipedia
 latest-release:
-    version: 1.10.5
-    date: 2026-04-23
+    version: 1.10.6
+    date: 2026-04-27
 changelog: https://github.com/connectbot/connectbot/blob/main/CHANGELOG.md
 client: yes
 server: no

--- a/_impls/cryptlib.md
+++ b/_impls/cryptlib.md
@@ -6,8 +6,8 @@ license: "[Dual license: Sleepycat or commercial](https://github.com/cryptlib/cr
 #first-release:
 #    date: YYYY-MM-DD
 latest-release:
-    version: 3.4.9
-    date: 2026-02-20
+    version: 3.4.9.1
+    date: 2026-04-30
 changelog: https://github.com/cryptlib/cryptlib/releases
 client: yes
 server: yes

--- a/_impls/dropbear.md
+++ b/_impls/dropbear.md
@@ -6,8 +6,8 @@ license: "[MIT style](https://github.com/mkj/dropbear/blob/master/LICENSE)"
 first-release:
     date: 2003-04-06    # according to CHANGES file
 latest-release:
-    version: 2025.89
-    date: 2025-12-16
+    version: 2026.90
+    date: 2026-05-03
 changelog: https://matt.ucc.asn.au/dropbear/CHANGES
 client: yes
 server: yes

--- a/_impls/jsch.md
+++ b/_impls/jsch.md
@@ -6,8 +6,8 @@ license: "[BSD style](https://github.com/mwiede/jsch/blob/master/LICENSE.txt)"
 first-release:
     date: 2002-10-20
 latest-release:
-    version: 2.28.0
-    date: 2026-03-31
+    version: 2.28.2
+    date: 2026-04-30
 changelog: https://github.com/mwiede/jsch/releases
 client: yes
 server: no

--- a/_impls/phpseclib.md
+++ b/_impls/phpseclib.md
@@ -6,8 +6,8 @@ license: "[MIT style](https://github.com/phpseclib/phpseclib/blob/master/LICENSE
 first-release:
     date: 2007-09-23
 latest-release:
-    version: 3.0.51
-    date: 2026-04-09
+    version: 3.0.52
+    date: 2026-04-27
 changelog: https://github.com/phpseclib/phpseclib/blob/master/CHANGELOG.md
 client: yes
 server: no

--- a/_impls/thrussh.md
+++ b/_impls/thrussh.md
@@ -6,8 +6,8 @@ license: "[Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0)"
 first-release:
     date: 2016-07-01
 latest-release:
-    version: 0.40.4
-    date: 2025-09-18
+    version: 0.40.5
+    date: 2026-04-25
 client: yes
 server: yes
 

--- a/_impls/ttssh2.md
+++ b/_impls/ttssh2.md
@@ -6,8 +6,8 @@ license: "[BSD style](https://teratermproject.github.io/manual/5/en/about/copyri
 first-release:
     date: 2004    # according to Wikipedia
 latest-release:
-    version: 5.6.0
-    date: 2026-02-27
+    version: 5.6.1
+    date: 2026-04-28
 changelog: https://teratermproject.github.io/manual/5/en/about/history.html
 client: yes
 server: no


### PR DESCRIPTION
- Update to latest IETF draft specs
- Update ConnectBot to 1.10.6
- Update phpseclib to 3.0.52
- Update JSch to 2.28.2
- Update Tera Term to 5.6.1
- Update cryptlib to 3.4.9.1
- Update Dropbear to 2026.90
- Update Thrussh to 0.40.5