### PR TITLE
Update to latest versions

### DIFF
--- a/_data/specs.yml
+++ b/_data/specs.yml
@@ -389,6 +389,14 @@ rfc9941:
         kex:
             - sntrup761x25519-sha512
 
+rfc9987:
+    name: RFC 9987
+    url: https://tools.ietf.org/html/rfc9987
+    title: "Secure Shell (SSH) Agent Protocol"
+    protocols:
+        extension:
+            - agent-forward
+
 draft-becker-cnsa2-ssh-profile-03:
     name: draft-becker-cnsa2-ssh-profile-03
     url: https://tools.ietf.org/html/draft-becker-cnsa2-ssh-profile-03.html
@@ -399,10 +407,10 @@ draft-gutmann-ssh-preauth-05:
     url: https://tools.ietf.org/html/draft-gutmann-ssh-preauth-05.html
     title: "A Pre-Authentication Mechanism for SSH [ expired 2026-08-14 ]"
 
-draft-harrison-sshm-mlkem-01:
-    name: draft-harrison-sshm-mlkem-01
-    url: https://tools.ietf.org/html/draft-harrison-sshm-mlkem-01.html
-    title: "Module-Lattice Key Exchange in SSH [ expired 2026-06-05 ]"
+draft-harrison-sshm-mlkem-02:
+    name: draft-harrison-sshm-mlkem-02
+    url: https://tools.ietf.org/html/draft-harrison-sshm-mlkem-02.html
+    title: "Module-Lattice Key Exchange in SSH [ expired 2026-11-28 ]"
     protocols:
         kex:
             - mlkem512-sha256
@@ -446,10 +454,10 @@ draft-ietf-sshm-cert-00:
             - rsa-sha2-256-cert-v01@openssh.com
             - rsa-sha2-512-cert-v01@openssh.com
 
-draft-ietf-sshm-chacha20-poly1305-02:
-    name: draft-ietf-sshm-chacha20-poly1305-02
-    url: https://tools.ietf.org/html/draft-ietf-sshm-chacha20-poly1305-02.html
-    title: "Secure Shell (SSH) authenticated encryption cipher: chacha20-poly1305 [ expired 2026-01-24 ]"
+draft-ietf-sshm-chacha20-poly1305-04:
+    name: draft-ietf-sshm-chacha20-poly1305-04
+    url: https://tools.ietf.org/html/draft-ietf-sshm-chacha20-poly1305-04.html
+    title: "Secure Shell (SSH) authenticated encryption cipher: chacha20-poly1305 [ expired 2026-11-27 ]"
     protocols:
         cipher:
             - chacha20-poly1305
@@ -471,14 +479,6 @@ draft-ietf-sshm-mlkem-hybrid-kex-10:
             - mlkem768nistp256-sha256
             - mlkem1024nistp384-sha384
             - mlkem768x25519-sha256
-
-draft-ietf-sshm-ssh-agent-16:
-    name: draft-ietf-sshm-ssh-agent-16
-    url: https://tools.ietf.org/html/draft-ietf-sshm-ssh-agent-16.html
-    title: "SSH Agent Protocol [ expired 2026-08-23 ]"
-    protocols:
-        extension:
-            - agent-forward
 
 draft-ietf-sshm-strict-kex-01:
     name: draft-ietf-sshm-strict-kex-01
@@ -603,13 +603,13 @@ draft-miller-sshm-aes-gcm-01:
             - aes128-gcm
             - aes256-gcm
 
-draft-miller-sshm-mldsa65-ed25519-composite-sigs-00:
-    name: draft-miller-sshm-mldsa65-ed25519-composite-sigs-00
-    url: https://tools.ietf.org/html/draft-miller-sshm-mldsa65-ed25519-composite-sigs-00.html
-    title: "ML-DSA 65/Ed255192 Composite Signatures in SSH [ expired 2026-10-30 ]"
+draft-miller-sshm-mldsa44-ed25519-composite-sigs-00:
+    name: draft-miller-sshm-mldsa44-ed25519-composite-sigs-00
+    url: https://tools.ietf.org/html/draft-miller-sshm-mldsa44-ed25519-composite-sigs-00.html
+    title: "ML-DSA 44/Ed255192 Composite Signatures in SSH [ expired 2026-12-04 ]"
     protocols:
         hostkey:
-            - ssh-mldsa65-ed25519@openssh.com
+            - ssh-mldsa44-ed25519@openssh.com
 
 draft-rpe-ssh-mldsa-03:
     name: draft-rpe-ssh-mldsa-03

--- a/_impls/apache-sshd.md
+++ b/_impls/apache-sshd.md
@@ -6,8 +6,8 @@ license: "[Apache-2.0](http://www.apache.org/licenses/LICENSE-2.0)"
 first-release:
     date: 2009      # according to Wikipedia
 latest-release:
-    version: 2.17.1
-    date: 2026-01-27
+    version: 2.18.0
+    date: 2026-05-28
 changelog: "https://github.com/apache/mina-sshd/blob/master/CHANGES.md"
 client: yes
 server: yes

--- a/_impls/cyclonessh.md
+++ b/_impls/cyclonessh.md
@@ -6,8 +6,8 @@ license: "Dual license: [GPLv2](http://www.gnu.org/licenses/old-licenses/gpl-2.0
 first-release:
     date: 2019-07-19
 latest-release:
-    version: 2.6.2
-    date: 2026-04-13
+    version: 2.6.4
+    date: 2026-05-29
 changelog: https://www.oryx-embedded.com/download.html#changelog
 client: yes
 server: yes

--- a/_impls/go-cryptography.md
+++ b/_impls/go-cryptography.md
@@ -6,8 +6,8 @@ license: "[BSD style](https://cs.opensource.google/go/x/crypto/+/master:LICENSE)
 first-release:
     date: 2022-10-19
 latest-release:
-    version: 0.51.0
-    date: 2026-05-08
+    version: 0.52.0
+    date: 2026-05-22
 #changelog: ?
 client: yes
 server: yes

--- a/_impls/putty.md
+++ b/_impls/putty.md
@@ -15,8 +15,8 @@ first-release:
 # the development code made its first successful SSH connection 1998-05-29.
 # So, all in all, this is why I give 1998 as date of the first release.
 latest-release:
-    version: 0.83
-    date: 2025-02-08
+    version: 0.84
+    date: 2026-05-22
 changelog: https://www.chiark.greenend.org.uk/~sgtatham/putty/changes.html
 client: yes
 server: no

--- a/_impls/russh.md
+++ b/_impls/russh.md
@@ -6,8 +6,8 @@ license: "[Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0)"
 first-release:
     date: 2022-03-13
 latest-release:
-    version: 0.60.1
-    date: 2026-04-20
+    version: 0.61.1
+    date: 2026-05-23
 changelog: https://github.com/Eugeny/russh/releases
 client: yes
 server: yes

--- a/_impls/tinyssh.md
+++ b/_impls/tinyssh.md
@@ -8,8 +8,8 @@ first-release:
     # see also https://news.ycombinator.com/item?id=7727738 from May 11, 2014
     # and http://tuxdiary.com/2014/05/11/tinyssh/
 latest-release:
-    version: 20260401
-    date: 2026-04-01
+    version: 20260601
+    date: 2026-06-01
 changelog: https://github.com/janmojzis/tinyssh/releases
 client: no
 server: yes


### PR DESCRIPTION
- Update Go Cryptography to 0.52.0
- Update Russh to 0.61.1
- Update CycloneSSH to 2.6.4
- Update TinySSH to 20260601
- Update Apache SSHD to 2.18.0
- Update PuTTY to 0.84
- Add RFC 9987 and update to latest IETF draft specs