### PR TITLE
Update to latest versions

### DIFF
--- a/_impls/asyncssh.md
+++ b/_impls/asyncssh.md
@@ -6,8 +6,8 @@ license: "[EPL v2.0](https://www.eclipse.org/legal/epl-2.0/faq.php)"
 first-release:
     date: 2013-09-14
 latest-release:
-    version: 2.23.0
-    date: 2026-05-08
+    version: 2.23.1
+    date: 2026-06-06
 changelog: https://asyncssh.readthedocs.io/en/latest/changes.html
 client: yes
 server: yes

--- a/_impls/connectbot.md
+++ b/_impls/connectbot.md
@@ -7,8 +7,8 @@ license: "[Apache-2.0](https://github.com/connectbot/connectbot/blob/main/LICENS
 first-release:
     date: 2007-11   # according to Wikipedia
 latest-release:
-    version: 1.10.7
-    date: 2026-05-09
+    version: 1.10.9
+    date: 2026-06-08
 changelog: https://github.com/connectbot/connectbot/blob/main/CHANGELOG.md
 client: yes
 server: no

--- a/_impls/cryptlib.md
+++ b/_impls/cryptlib.md
@@ -6,8 +6,8 @@ license: "[Dual license: Sleepycat or commercial](https://github.com/cryptlib/cr
 #first-release:
 #    date: YYYY-MM-DD
 latest-release:
-    version: 3.4.9.1
-    date: 2026-04-30
+    version: 3.4.9.2
+    date: 2026-06-08
 changelog: https://github.com/cryptlib/cryptlib/releases
 client: yes
 server: yes

--- a/_impls/erlang.md
+++ b/_impls/erlang.md
@@ -6,8 +6,8 @@ license: "[Apache-2.0](https://github.com/erlang/otp/blob/maint/LICENSE.txt)"
 first-release:
     date: 2005-10-25
 latest-release:
-    version: 6.0 (OTP 29.0)
-    date: 2026-05-13
+    version: 6.0.1 (OTP 29.0.2)
+    date: 2026-06-10
 changelog: https://www.erlang.org/doc/apps/ssh/notes.html
 client: yes
 server: yes

--- a/_impls/go-cryptography.md
+++ b/_impls/go-cryptography.md
@@ -6,8 +6,8 @@ license: "[BSD style](https://cs.opensource.google/go/x/crypto/+/master:LICENSE)
 first-release:
     date: 2022-10-19
 latest-release:
-    version: 0.52.0
-    date: 2026-05-22
+    version: 0.53.0
+    date: 2026-06-08
 #changelog: ?
 client: yes
 server: yes

--- a/_impls/hpn-ssh.md
+++ b/_impls/hpn-ssh.md
@@ -6,8 +6,8 @@ license: "[BSD](https://github.com/rapier1/hpn-ssh/blob/master/LICENCE)"
 first-release:
     date: 2004
 latest-release:
-    version: 18.8.0
-    date: 2025-10-23
+    version: 18.9.0
+    date: 2026-06-09
 changelog: https://github.com/rapier1/hpn-ssh/releases
 client: yes
 server: yes
@@ -92,6 +92,7 @@ protocols:
         - hostbased
         - publickey-hostbound-v00@openssh.com
     extension:
+        - agent-forward
         - ext-info-in-auth@openssh.com
         - ping@openssh.com
         - publickey-hostbound@openssh.com

--- a/_impls/jsch.md
+++ b/_impls/jsch.md
@@ -6,8 +6,8 @@ license: "[BSD style](https://github.com/mwiede/jsch/blob/master/LICENSE.txt)"
 first-release:
     date: 2002-10-20
 latest-release:
-    version: 2.28.2
-    date: 2026-04-30
+    version: 2.28.3
+    date: 2026-06-10
 changelog: https://github.com/mwiede/jsch/releases
 client: yes
 server: no

--- a/_impls/phpseclib.md
+++ b/_impls/phpseclib.md
@@ -6,8 +6,8 @@ license: "[MIT style](https://github.com/phpseclib/phpseclib/blob/master/LICENSE
 first-release:
     date: 2007-09-23
 latest-release:
-    version: 3.0.52
-    date: 2026-04-27
+    version: 3.0.53
+    date: 2026-06-09
 changelog: https://github.com/phpseclib/phpseclib/blob/master/CHANGELOG.md
 client: yes
 server: no

--- a/_impls/pkix-ssh.md
+++ b/_impls/pkix-ssh.md
@@ -6,8 +6,8 @@ license: "[BSD](https://gitlab.com/secsh/pkixssh/-/blob/master/LICENCE)"
 first-release:
     date: 2002-04-04
 latest-release:
-    version: 18.0.2
-    date: 2026-04-05
+    version: 18.0.3
+    date: 2026-06-05
 changelog: https://roumenpetrov.info/secsh/#news
 client: yes
 server: yes

--- a/_impls/russh.md
+++ b/_impls/russh.md
@@ -6,8 +6,8 @@ license: "[Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0)"
 first-release:
     date: 2022-03-13
 latest-release:
-    version: 0.61.1
-    date: 2026-05-23
+    version: 0.61.2
+    date: 2026-06-05
 changelog: https://github.com/Eugeny/russh/releases
 client: yes
 server: yes

--- a/_impls/twisted.md
+++ b/_impls/twisted.md
@@ -7,7 +7,7 @@ first-release:
     date: 2002-07-07    # Conch renamed from twisted.secsh
 latest-release:
     version: 26.4.0
-    date: 2025-05-11
+    date: 2026-05-11
 changelog: https://github.com/twisted/twisted/blob/trunk/NEWS.rst
 client: yes
 server: yes


### PR DESCRIPTION
- Update Russh to 0.61.2
- Update Go Cryptography to 0.53.0
- Update Erlang ssh library to 6.0.1
- Update ConnectBot to 1.10.9
- Update AsyncSSH to 2.23.1
- Update cryptlib to 3.4.9.2
- Update JSch to 2.28.3
- Update phpseclib to 3.0.53
- Update PKIX-SSH to 18.0.3
- Update HPN-SSH to 18.9.0
- Correct Twisted Conch 26.4.0 release date