### PR TITLE
Update to latest versions

### DIFF
--- a/_data/specs.yml
+++ b/_data/specs.yml
@@ -397,10 +397,10 @@ rfc9987:
         extension:
             - agent-forward
 
-draft-becker-cnsa2-ssh-profile-03:
-    name: draft-becker-cnsa2-ssh-profile-03
-    url: https://tools.ietf.org/html/draft-becker-cnsa2-ssh-profile-03.html
-    title: "Commercial National Security Algorithm (CNSA) Suite 2.0 Profile for SSH [ expired 2026-11-09 ]"
+draft-becker-cnsa2-ssh-profile-04:
+    name: draft-becker-cnsa2-ssh-profile-04
+    url: https://tools.ietf.org/html/draft-becker-cnsa2-ssh-profile-04.html
+    title: "Commercial National Security Algorithm (CNSA) Suite 2.0 Profile for SSH [ expired 2027-01-07 ]"
 
 draft-gutmann-ssh-preauth-05:
     name: draft-gutmann-ssh-preauth-05
@@ -667,10 +667,10 @@ draft-ssh-global-requests-ok-00:
         extension:
             - global-requests-ok
 
-draft-sun-ssh-composite-sigs-02:
-    name: draft-sun-ssh-composite-sigs-02
-    url: https://tools.ietf.org/html/draft-sun-ssh-composite-sigs-02.html
-    title: "Composite ML-DSA Signatures for SSH [ expired 2026-07-09 ]"
+draft-sun-ssh-composite-sigs-03:
+    name: draft-sun-ssh-composite-sigs-03
+    url: https://tools.ietf.org/html/draft-sun-ssh-composite-sigs-03.html
+    title: "Composite ML-DSA Signatures for SSH [ expired 2027-01-07 ]"
     protocols:
         hostkey:
             - ssh-mldsa44-es256

--- a/_impls/cryptlib.md
+++ b/_impls/cryptlib.md
@@ -6,8 +6,8 @@ license: "[Dual license: Sleepycat or commercial](https://github.com/cryptlib/cr
 #first-release:
 #    date: YYYY-MM-DD
 latest-release:
-    version: 3.4.9.2
-    date: 2026-06-08
+    version: 3.4.9.3
+    date: 2026-07-08
 changelog: https://github.com/cryptlib/cryptlib/releases
 client: yes
 server: yes

--- a/_impls/dropbear.md
+++ b/_impls/dropbear.md
@@ -6,8 +6,8 @@ license: "[MIT style](https://github.com/mkj/dropbear/blob/master/LICENSE)"
 first-release:
     date: 2003-04-06    # according to CHANGES file
 latest-release:
-    version: 2026.91
-    date: 2026-05-10
+    version: 2026.92
+    date: 2026-07-06
 changelog: https://matt.ucc.asn.au/dropbear/CHANGES
 client: yes
 server: yes

--- a/_impls/erlang.md
+++ b/_impls/erlang.md
@@ -6,8 +6,8 @@ license: "[Apache-2.0](https://github.com/erlang/otp/blob/maint/LICENSE.txt)"
 first-release:
     date: 2005-10-25
 latest-release:
-    version: 6.0.1 (OTP 29.0.2)
-    date: 2026-06-10
+    version: 6.0.2 (OTP 29.0.3)
+    date: 2026-07-02
 changelog: https://www.erlang.org/doc/apps/ssh/notes.html
 client: yes
 server: yes

--- a/_impls/go-cryptography.md
+++ b/_impls/go-cryptography.md
@@ -6,8 +6,8 @@ license: "[BSD style](https://cs.opensource.google/go/x/crypto/+/master:LICENSE)
 first-release:
     date: 2022-10-19
 latest-release:
-    version: 0.53.0
-    date: 2026-06-08
+    version: 0.54.0
+    date: 2026-07-08
 #changelog: ?
 client: yes
 server: yes

--- a/_impls/jsch.md
+++ b/_impls/jsch.md
@@ -6,8 +6,8 @@ license: "[BSD style](https://github.com/mwiede/jsch/blob/master/LICENSE.txt)"
 first-release:
     date: 2002-10-20
 latest-release:
-    version: 2.28.3
-    date: 2026-06-10
+    version: 2.28.4
+    date: 2026-07-09
 changelog: https://github.com/mwiede/jsch/releases
 client: yes
 server: no

--- a/_impls/openssh.md
+++ b/_impls/openssh.md
@@ -6,8 +6,8 @@ license: "[BSD](https://github.com/openssh/openssh-portable/blob/master/LICENCE)
 first-release:
     date: 1999-12-01    # according to Wikipedia
 latest-release:
-    version: 10.3
-    date: 2026-04-02
+    version: 10.4
+    date: 2026-07-06
 changelog: https://www.openssh.com/releasenotes.html
 client: yes
 server: yes
@@ -48,6 +48,7 @@ protocols:
         - ecdsa-sha2-nistp384-cert-v01@openssh.com
         - ecdsa-sha2-nistp521-cert-v01@openssh.com
         - ssh-ed25519-cert-v01@openssh.com  # since 6.5
+        - ssh-mldsa44-ed25519-cert-v01@openssh.com # since 10.4
         - ssh-rsa-cert-v01@openssh.com
         #- ssh-dss-cert-v01@openssh.com      # removed in 10.0
         - rsa-sha2-256-cert-v01@openssh.com
@@ -58,6 +59,7 @@ protocols:
         - ecdsa-sha2-nistp384               # since 5.7
         - ecdsa-sha2-nistp521               # since 5.7
         - ssh-ed25519                       # since 6.5
+        - ssh-mldsa44-ed25519@openssh.com   # since 10.4
         - ssh-rsa
         #- ssh-dss                           # removed in 10.0
         - sk-ecdsa-sha2-nistp256-cert-v01@openssh.com

--- a/_impls/pkix-ssh.md
+++ b/_impls/pkix-ssh.md
@@ -6,8 +6,8 @@ license: "[BSD](https://gitlab.com/secsh/pkixssh/-/blob/master/LICENCE)"
 first-release:
     date: 2002-04-04
 latest-release:
-    version: 18.0.3
-    date: 2026-06-05
+    version: 19.0
+    date: 2026-07-08
 changelog: https://roumenpetrov.info/secsh/#news
 client: yes
 server: yes
@@ -32,6 +32,9 @@ protocols:
         - x509v3-ecdsa-sha2-nistp256
         - x509v3-ecdsa-sha2-nistp384
         - x509v3-ecdsa-sha2-nistp521
+        - x509v3-mldsa-44
+        - x509v3-mldsa-65
+        - x509v3-mldsa-87
         - x509v3-rsa2048-sha256
         - x509v3-ssh-rsa
         - x509v3-sign-rsa
@@ -51,6 +54,9 @@ protocols:
         - ecdsa-sha2-nistp256
         - ecdsa-sha2-nistp384
         - ecdsa-sha2-nistp521
+        - mldsa-44
+        - mldsa-65
+        - mldsa-87
         - ssh-ed25519
         - ssh-rsa
         - ssh-dss                           # disabled by default

--- a/_impls/russh.md
+++ b/_impls/russh.md
@@ -6,8 +6,8 @@ license: "[Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0)"
 first-release:
     date: 2022-03-13
 latest-release:
-    version: 0.61.2
-    date: 2026-06-05
+    version: 0.62.2
+    date: 2026-07-06
 changelog: https://github.com/Eugeny/russh/releases
 client: yes
 server: yes

--- a/_impls/swift-nio-ssh.md
+++ b/_impls/swift-nio-ssh.md
@@ -6,8 +6,8 @@ license: "[Apache-2.0](https://github.com/apple/swift-nio-ssh/blob/main/LICENSE.
 first-release:
     date: 2020-04-14
 latest-release:
-    version: 0.13.0
-    date: 2026-04-16
+    version: 0.14.0
+    date: 2026-07-06
 changelog: https://github.com/apple/swift-nio-ssh/releases
 client: yes
 server: yes


### PR DESCRIPTION
- Update OpenSSH to 10.4
- Update Dropbear to 2026.92
- Update SwiftNIO SSH to 0.14.0
- Update Erlang ssh library to 6.0.2
- Update cryptlib to 3.4.9.3
- Update Go Cryptography to 0.54.0
- Update PKIX-SSH to 19.0
- Update Russh to 0.62.2
- Update to latest IETF draft specs
- Update JSch to 2.28.4