### PR TITLE
Update to latest versions

### DIFF
--- a/_data/specs.yml
+++ b/_data/specs.yml
@@ -402,10 +402,10 @@ rfc9987:
         extension:
             - agent-forward
 
-draft-becker-cnsa2-ssh-profile-04:
-    name: draft-becker-cnsa2-ssh-profile-04
-    url: https://tools.ietf.org/html/draft-becker-cnsa2-ssh-profile-04.html
-    title: "Commercial National Security Algorithm (CNSA) Suite 2.0 Profile for SSH [ expired 2027-01-07 ]"
+draft-becker-cnsa2-ssh-profile-05:
+    name: draft-becker-cnsa2-ssh-profile-05
+    url: https://tools.ietf.org/html/draft-becker-cnsa2-ssh-profile-05.html
+    title: "Commercial National Security Algorithm (CNSA) Suite 2.0 Profile for SSH [ expired 2027-01-22 ]"
 
 draft-gutmann-ssh-preauth-05:
     name: draft-gutmann-ssh-preauth-05
@@ -485,10 +485,10 @@ draft-ietf-sshm-mlkem-hybrid-kex-10:
             - mlkem1024nistp384-sha384
             - mlkem768x25519-sha256
 
-draft-ietf-sshm-strict-kex-01:
-    name: draft-ietf-sshm-strict-kex-01
-    url: https://tools.ietf.org/html/draft-ietf-sshm-strict-kex-01.html
-    title: "SSH Strict KEX extension [ expired 2026-05-14 ]"
+draft-ietf-sshm-strict-kex-02:
+    name: draft-ietf-sshm-strict-kex-02
+    url: https://tools.ietf.org/html/draft-ietf-sshm-strict-kex-02.html
+    title: "SSH Strict KEX extension [ expired 2027-01-23 ]"
     protocols:
         kex:
             - kex-strict-c
@@ -547,10 +547,10 @@ draft-josefsson-ssh-sphincs-02:
             - ssh-ed448-slh-dsa-sha2-256-24
             - ssh-ed448-slh-dsa-shake-256-24
 
-draft-josefsson-sshsig-format-03:
-    name: draft-josefsson-sshsig-format-03
-    url: https://tools.ietf.org/html/draft-josefsson-sshsig-format-03.html
-    title: "Lightweight Secure Shell (SSH) Signature Format [ expired 2026-01-08 ]"
+draft-josefsson-sshsig-format-04:
+    name: draft-josefsson-sshsig-format-04
+    url: https://tools.ietf.org/html/draft-josefsson-sshsig-format-04.html
+    title: "Lightweight Secure Shell (SSH) Signature Format [ expired 2027-01-23 ]"
 
 draft-kanno-secsh-camellia-02:
     name: draft-kanno-secsh-camellia-02

--- a/_impls/dropbear.md
+++ b/_impls/dropbear.md
@@ -6,8 +6,8 @@ license: "[MIT style](https://github.com/mkj/dropbear/blob/master/LICENSE)"
 first-release:
     date: 2003-04-06    # according to CHANGES file
 latest-release:
-    version: 2026.92
-    date: 2026-07-06
+    version: 2026.93
+    date: 2026-07-21
 changelog: https://matt.ucc.asn.au/dropbear/CHANGES
 client: yes
 server: yes

--- a/_impls/jsch.md
+++ b/_impls/jsch.md
@@ -6,8 +6,8 @@ license: "[BSD style](https://github.com/mwiede/jsch/blob/master/LICENSE.txt)"
 first-release:
     date: 2002-10-20
 latest-release:
-    version: 2.28.4
-    date: 2026-07-09
+    version: 2.28.5
+    date: 2026-07-23
 changelog: https://github.com/mwiede/jsch/releases
 client: yes
 server: no

--- a/_impls/libssh.md
+++ b/_impls/libssh.md
@@ -10,9 +10,9 @@ first-release:
 # Looking at the initial commit in the git repository, it contains
 # a CHANGELOG which contains the date of the initial release.
 latest-release:
-    version: 0.12.0
-    date: 2026-02-10
-changelog: https://git.libssh.org/projects/libssh.git/tree/CHANGELOG?h=libssh-0.12.0
+    version: 0.12.1
+    date: 2026-07-21
+changelog: https://git.libssh.org/projects/libssh.git/tree/CHANGELOG?h=libssh-0.12.1
 client: yes
 server: yes
 library: both

--- a/_impls/russh.md
+++ b/_impls/russh.md
@@ -6,8 +6,8 @@ license: "[Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0)"
 first-release:
     date: 2022-03-13
 latest-release:
-    version: 0.62.2
-    date: 2026-07-06
+    version: 0.62.4
+    date: 2026-07-22
 changelog: https://github.com/Eugeny/russh/releases
 client: yes
 server: yes

--- a/_impls/swift-nio-ssh.md
+++ b/_impls/swift-nio-ssh.md
@@ -6,8 +6,8 @@ license: "[Apache-2.0](https://github.com/apple/swift-nio-ssh/blob/main/LICENSE.
 first-release:
     date: 2020-04-14
 latest-release:
-    version: 0.14.0
-    date: 2026-07-06
+    version: 0.14.1
+    date: 2026-07-15
 changelog: https://github.com/apple/swift-nio-ssh/releases
 client: yes
 server: yes

--- a/_impls/ttssh2.md
+++ b/_impls/ttssh2.md
@@ -6,8 +6,8 @@ license: "[BSD style](https://teratermproject.github.io/manual/5/en/about/copyri
 first-release:
     date: 2004    # according to Wikipedia
 latest-release:
-    version: 5.6.1
-    date: 2026-04-28
+    version: 5.6.2
+    date: 2026-07-15
 changelog: https://teratermproject.github.io/manual/5/en/about/history.html
 client: yes
 server: no


### PR DESCRIPTION
- Update JSch to 2.28.5
- Update Dropbear to 2026.93
- Update Russh to 0.62.4
- Update SwiftNIO SSH to 0.14.1
- Update Tera Term to 5.6.2
- Update libssh to 0.12.1
- Update to latest IETF draft specs