### PR TITLE
Update to latest versions

### DIFF
--- a/_data/specs.yml
+++ b/_data/specs.yml
@@ -608,6 +608,15 @@ draft-miller-sshm-aes-gcm-01:
             - aes128-gcm
             - aes256-gcm
 
+draft-miller-sshm-composite-sigs-00:
+    name: draft-miller-sshm-composite-sigs-00
+    url: https://tools.ietf.org/html/draft-miller-sshm-composite-sigs-00.html
+    title: "Post-Quantum Composite Signatures in SSH [ expired 2027-01-24 ]"
+    protocols:
+        hostkey:
+            - ssh-mldsa44-ed25519
+            - ssh-mldsa87-p384
+
 draft-miller-sshm-mldsa44-ed25519-composite-sigs-00:
     name: draft-miller-sshm-mldsa44-ed25519-composite-sigs-00
     url: https://tools.ietf.org/html/draft-miller-sshm-mldsa44-ed25519-composite-sigs-00.html

--- a/_impls/dropbear.md
+++ b/_impls/dropbear.md
@@ -6,8 +6,8 @@ license: "[MIT style](https://github.com/mkj/dropbear/blob/master/LICENSE)"
 first-release:
     date: 2003-04-06    # according to CHANGES file
 latest-release:
-    version: 2026.93
-    date: 2026-07-21
+    version: 2026.94
+    date: 2026-07-23
 changelog: https://matt.ucc.asn.au/dropbear/CHANGES
 client: yes
 server: yes

--- a/_impls/erlang.md
+++ b/_impls/erlang.md
@@ -6,8 +6,8 @@ license: "[Apache-2.0](https://github.com/erlang/otp/blob/maint/LICENSE.txt)"
 first-release:
     date: 2005-10-25
 latest-release:
-    version: 6.0.2 (OTP 29.0.3)
-    date: 2026-07-02
+    version: 6.0.3 (OTP 29.0.4)
+    date: 2026-07-27
 changelog: https://www.erlang.org/doc/apps/ssh/notes.html
 client: yes
 server: yes

--- a/_impls/jsch.md
+++ b/_impls/jsch.md
@@ -6,8 +6,8 @@ license: "[BSD style](https://github.com/mwiede/jsch/blob/master/LICENSE.txt)"
 first-release:
     date: 2002-10-20
 latest-release:
-    version: 2.28.5
-    date: 2026-07-23
+    version: 2.28.6
+    date: 2026-07-29
 changelog: https://github.com/mwiede/jsch/releases
 client: yes
 server: no

--- a/_impls/libssh.md
+++ b/_impls/libssh.md
@@ -10,9 +10,9 @@ first-release:
 # Looking at the initial commit in the git repository, it contains
 # a CHANGELOG which contains the date of the initial release.
 latest-release:
-    version: 0.12.1
-    date: 2026-07-21
-changelog: https://git.libssh.org/projects/libssh.git/tree/CHANGELOG?h=libssh-0.12.1
+    version: 0.12.2
+    date: 2026-07-28
+changelog: https://git.libssh.org/projects/libssh.git/tree/CHANGELOG?h=libssh-0.12.2
 client: yes
 server: yes
 library: both

--- a/_impls/moussh.md
+++ b/_impls/moussh.md
@@ -6,9 +6,8 @@ license: "[Public Domain](http://ftp.rodents-montreal.org/mouse/git-unpacked/mou
 #first-release:
 #    date: YYYY-MM-DD
 latest-release:
-    version: 0.9.2fe6d57aff
-    version: 0.9.20250724104234w0400.e4f5ecd6ab
-    date: 2025-07-24
+    version: 0.9.20260715151218w0400.4c6d154c8f
+    date: 2026-07-15
 #changelog: TODO
 client: yes
 server: yes

--- a/_impls/swift-nio-ssh.md
+++ b/_impls/swift-nio-ssh.md
@@ -6,8 +6,8 @@ license: "[Apache-2.0](https://github.com/apple/swift-nio-ssh/blob/main/LICENSE.
 first-release:
     date: 2020-04-14
 latest-release:
-    version: 0.14.1
-    date: 2026-07-15
+    version: 0.15.0
+    date: 2026-07-28
 changelog: https://github.com/apple/swift-nio-ssh/releases
 client: yes
 server: yes


### PR DESCRIPTION
- Update JSch to 2.28.6
- Update Dropbear to 2026.94
- Update libssh to 0.12.2
- Update SwiftNIO SSH to 0.15.0
- Update Erlang ssh library to 6.0.3
- Update moussh to 0.9.20260715151218w0400.4c6d154c8f
- Update to latest IETF draft specs