### PR TITLE
Update to latest versions

### DIFF
--- a/_data/specs.yml
+++ b/_data/specs.yml
@@ -645,10 +645,10 @@ draft-rpe-ssh-x509-mldsa-01:
             - x509v3-mldsa-65
             - x509v3-mldsa-87
 
-draft-sfluhrer-ssh-mldsa-06:
-    name: draft-sfluhrer-ssh-mldsa-06
-    url: https://tools.ietf.org/html/draft-sfluhrer-ssh-mldsa-06.html
-    title: "SSH Support of ML-DSA [ expired 2026-10-09 ]"
+draft-sfluhrer-ssh-mldsa-07:
+    name: draft-sfluhrer-ssh-mldsa-07
+    url: https://tools.ietf.org/html/draft-sfluhrer-ssh-mldsa-07.html
+    title: "SSH Support of ML-DSA [ expired 2027-02-15 ]"
     protocols:
         hostkey:
             - ssh-mldsa-44

--- a/_impls/absolutetelnet.md
+++ b/_impls/absolutetelnet.md
@@ -5,8 +5,8 @@ license: Proprietary
 first-release:
     date: 1996      # according to Wikipedia
 latest-release:
-    version: 13.16
-    date: 2026-05-20
+    version: 14.02
+    date: 2026-08-14
 changelog: https://www.celestialsoftware.net/version-history
 client: yes
 server: no

--- a/_impls/cryptlib.md
+++ b/_impls/cryptlib.md
@@ -6,8 +6,8 @@ license: "[Dual license: Sleepycat or commercial](https://github.com/cryptlib/cr
 #first-release:
 #    date: YYYY-MM-DD
 latest-release:
-    version: 3.4.9.3
-    date: 2026-07-08
+    version: 3.4.9.4
+    date: 2026-08-13
 changelog: https://github.com/cryptlib/cryptlib/releases
 client: yes
 server: yes

--- a/_impls/go-cryptography.md
+++ b/_impls/go-cryptography.md
@@ -6,8 +6,8 @@ license: "[BSD style](https://cs.opensource.google/go/x/crypto/+/master:LICENSE)
 first-release:
     date: 2022-10-19
 latest-release:
-    version: 0.54.0
-    date: 2026-07-08
+    version: 0.55.0
+    date: 2026-08-11
 #changelog: ?
 client: yes
 server: yes

--- a/_impls/openssh.md
+++ b/_impls/openssh.md
@@ -6,8 +6,8 @@ license: "[BSD](https://github.com/openssh/openssh-portable/blob/master/LICENCE)
 first-release:
     date: 1999-12-01    # according to Wikipedia
 latest-release:
-    version: 10.4
-    date: 2026-07-06
+    version: 10.5
+    date: 2026-08-11
 changelog: https://www.openssh.com/releasenotes.html
 client: yes
 server: yes
@@ -86,6 +86,7 @@ protocols:
         - sntrup761x25519-sha512@openssh.com # since 8.5
         - sntrup761x25519-sha512            # since 9.9
         - mlkem768x25519-sha256             # since 9.9
+        - mlkem768nistp256-sha256           # since 10.5
     mac:
         - umac-64-etm@openssh.com           # since 6.2
         - umac-128-etm@openssh.com          # since 6.2

--- a/_impls/pkix-ssh.md
+++ b/_impls/pkix-ssh.md
@@ -6,8 +6,8 @@ license: "[BSD](https://gitlab.com/secsh/pkixssh/-/blob/master/LICENCE)"
 first-release:
     date: 2002-04-04
 latest-release:
-    version: 19.0.1
-    date: 2026-07-09
+    version: 19.1
+    date: 2026-08-13
 changelog: https://roumenpetrov.info/secsh/#news
 client: yes
 server: yes

--- a/_impls/putty.md
+++ b/_impls/putty.md
@@ -15,8 +15,8 @@ first-release:
 # the development code made its first successful SSH connection 1998-05-29.
 # So, all in all, this is why I give 1998 as date of the first release.
 latest-release:
-    version: 0.84
-    date: 2026-05-22
+    version: 0.85
+    date: 2026-08-16
 changelog: https://www.chiark.greenend.org.uk/~sgtatham/putty/changes.html
 client: yes
 server: no

--- a/_impls/russh.md
+++ b/_impls/russh.md
@@ -6,8 +6,8 @@ license: "[Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0)"
 first-release:
     date: 2022-03-13
 latest-release:
-    version: 0.62.5
-    date: 2026-07-31
+    version: 0.62.7
+    date: 2026-08-17
 changelog: https://github.com/Eugeny/russh/releases
 client: yes
 server: yes
@@ -76,6 +76,7 @@ protocols:
         - publickey
         - password
         - keyboard-interactive
+        - gssapi-with-mic
     extension:
         - server-sig-algs
 

--- a/_impls/ssh-net.md
+++ b/_impls/ssh-net.md
@@ -6,8 +6,8 @@ license: "[MIT license](https://github.com/sshnet/SSH.NET/blob/develop/LICENSE)"
 first-release:
     date: 2010-09-16
 latest-release:
-    version: 2025.1.0
-    date: 2025-10-27
+    version: 2026.0.0
+    date: 2026-08-09
 changelog: https://github.com/sshnet/SSH.NET/releases
 client: yes
 server: no

--- a/_impls/thrussh.md
+++ b/_impls/thrussh.md
@@ -6,8 +6,8 @@ license: "[Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0)"
 first-release:
     date: 2016-07-01
 latest-release:
-    version: 0.43.0
-    date: 2026-08-01
+    version: 0.45.0
+    date: 2026-08-14
 client: yes
 server: yes
 


### PR DESCRIPTION
- Update Thrussh to 0.45.0
- Update Russh to 0.62.7
- Update PKIX-SSH to 19.1
- Update cryptlib to 3.4.9.4
- Update Go Cryptography to 0.55.0
- Update OpenSSH to 10.5
- Update PuTTY to 0.85
- Update AbsoluteTelnet to 14.02
- Update SSH.NET to 2026.0.0
- Update to latest IETF draft specs