### PR TITLE
Update to latest versions

### DIFF
--- a/_data/specs.yml
+++ b/_data/specs.yml
@@ -402,6 +402,17 @@ rfc9987:
         extension:
             - agent-forward
 
+rfc10042:
+    name: RFC 10042
+    url: https://tools.ietf.org/html/rfc10042
+    errata: https://www.rfc-editor.org/errata_search.php?rfc=10042
+    title: "Post-Quantum/Traditional Hybrid Key Exchange with the Module-Lattice-Based Key-Encapsulation Mechanism for Use in SSH"
+    protocols:
+        kex:
+            - mlkem768nistp256-sha256
+            - mlkem1024nistp384-sha384
+            - mlkem768x25519-sha256
+
 draft-becker-cnsa2-ssh-profile-05:
     name: draft-becker-cnsa2-ssh-profile-05
     url: https://tools.ietf.org/html/draft-becker-cnsa2-ssh-profile-05.html
@@ -483,16 +494,6 @@ draft-ietf-sshm-hostkey-update-00:
     protocols:
         extension:
             - hostkeys
-
-draft-ietf-sshm-mlkem-hybrid-kex-10:
-    name: draft-ietf-sshm-mlkem-hybrid-kex-10
-    url: https://tools.ietf.org/html/draft-ietf-sshm-mlkem-hybrid-kex-10.html
-    title: "PQ/T Hybrid Key Exchange with ML-KEM in SSH [ expired 2026-08-30 ]"
-    protocols:
-        kex:
-            - mlkem768nistp256-sha256
-            - mlkem1024nistp384-sha384
-            - mlkem768x25519-sha256
 
 draft-ietf-sshm-strict-kex-02:
     name: draft-ietf-sshm-strict-kex-02
@@ -645,10 +646,10 @@ draft-rpe-ssh-x509-mldsa-01:
             - x509v3-mldsa-65
             - x509v3-mldsa-87
 
-draft-sfluhrer-ssh-mldsa-07:
-    name: draft-sfluhrer-ssh-mldsa-07
-    url: https://tools.ietf.org/html/draft-sfluhrer-ssh-mldsa-07.html
-    title: "SSH Support of ML-DSA [ expired 2027-02-15 ]"
+draft-sfluhrer-ssh-mldsa-08:
+    name: draft-sfluhrer-ssh-mldsa-08
+    url: https://tools.ietf.org/html/draft-sfluhrer-ssh-mldsa-08.html
+    title: "SSH Support of ML-DSA [ expired 2027-03-01 ]"
     protocols:
         hostkey:
             - ssh-mldsa-44

--- a/_impls/absolutetelnet.md
+++ b/_impls/absolutetelnet.md
@@ -5,8 +5,8 @@ license: Proprietary
 first-release:
     date: 1996      # according to Wikipedia
 latest-release:
-    version: 14.04
-    date: 2026-08-25
+    version: 14.07
+    date: 2026-09-01
 changelog: https://www.celestialsoftware.net/version-history
 client: yes
 server: no

--- a/_impls/cryptlib.md
+++ b/_impls/cryptlib.md
@@ -6,8 +6,8 @@ license: "[Dual license: Sleepycat or commercial](https://github.com/cryptlib/cr
 #first-release:
 #    date: YYYY-MM-DD
 latest-release:
-    version: 3.4.9.4
-    date: 2026-08-13
+    version: 3.4.9.5
+    date: 2026-08-31
 changelog: https://github.com/cryptlib/cryptlib/releases
 client: yes
 server: yes

--- a/_impls/erlang.md
+++ b/_impls/erlang.md
@@ -6,8 +6,8 @@ license: "[Apache-2.0](https://github.com/erlang/otp/blob/maint/LICENSE.txt)"
 first-release:
     date: 2005-10-25
 latest-release:
-    version: 6.0.4 (OTP 29.0.5)
-    date: 2026-08-04
+    version: 6.0.5 (OTP 29.0.6)
+    date: 2026-09-01
 changelog: https://www.erlang.org/doc/apps/ssh/notes.html
 client: yes
 server: yes

--- a/_impls/go-cryptography.md
+++ b/_impls/go-cryptography.md
@@ -6,8 +6,8 @@ license: "[BSD style](https://cs.opensource.google/go/x/crypto/+/master:LICENSE)
 first-release:
     date: 2022-10-19
 latest-release:
-    version: 0.55.0
-    date: 2026-08-11
+    version: 0.56.0
+    date: 2026-09-02
 #changelog: ?
 client: yes
 server: yes

--- a/_impls/thrussh.md
+++ b/_impls/thrussh.md
@@ -6,8 +6,8 @@ license: "[Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0)"
 first-release:
     date: 2016-07-01
 latest-release:
-    version: 0.48.0
-    date: 2026-08-21
+    version: 0.49.0
+    date: 2026-08-28
 client: yes
 server: yes
 


### PR DESCRIPTION
- Update AbsoluteTelnet to 14.07
- Update Thrussh to 0.49.0
- Update cryptlib to 3.4.9.5
- Update Go Cryptography to 0.56.0
- Update Erlang ssh library to 6.0.5
- Update to latest IETF draft specs & add RFC 10042